### PR TITLE
MAINT: Remove unnecessary dependency.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ SQLAlchemy>=1.0.5
 alembic>=0.7.6
 backports.ssl-match-hostname>=3.4.0.2
 certifi>=14.05.14
-fancycompleter>=0.4
 ipython==3.2.1
 jsonschema>=2.4.0
 mistune>=0.5.0


### PR DESCRIPTION
fancycompleter is a tab completion library, which we definitely don't
need.  It was probably accidentally added as development cruft.

cc @richafrank 