### PR TITLE
 Improve IPython 4.0 compatibility

### DIFF
--- a/pgcontents/api_utils.py
+++ b/pgcontents/api_utils.py
@@ -11,10 +11,16 @@ from functools import wraps
 import mimetypes
 import posixpath
 
-from IPython.nbformat import (
-    reads,
-    writes,
-)
+try:
+    from nbformat import (
+        reads,
+        writes,
+    )
+except ImportError:
+    from IPython.nbformat import (
+        reads,
+        writes,
+    )
 from tornado.web import HTTPError
 from .error import PathOutsideRoot
 

--- a/pgcontents/checkpoints.py
+++ b/pgcontents/checkpoints.py
@@ -3,10 +3,16 @@ An IPython FileContentsManager that uses Postgres for checkpoints.
 """
 from __future__ import unicode_literals
 
-from IPython.html.services.contents.checkpoints import GenericCheckpointsMixin
-from IPython.html.services.contents.manager import (
-    Checkpoints,
-)
+try:
+    from notebook.services.contents.checkpoints import GenericCheckpointsMixin
+    from notebook.services.contents.manager import (
+        Checkpoints,
+    )
+except ImportError:
+    from IPython.html.services.contents.checkpoints import GenericCheckpointsMixin
+    from IPython.html.services.contents.manager import (
+        Checkpoints,
+    )
 
 from .api_utils import (
     _decode_unknown_from_base64,

--- a/pgcontents/checkpoints.py
+++ b/pgcontents/checkpoints.py
@@ -4,12 +4,16 @@ An IPython FileContentsManager that uses Postgres for checkpoints.
 from __future__ import unicode_literals
 
 try:
-    from notebook.services.contents.checkpoints import GenericCheckpointsMixin
+    from notebook.services.contents.checkpoints import (
+        GenericCheckpointsMixin,
+    )
     from notebook.services.contents.manager import (
         Checkpoints,
     )
 except ImportError:
-    from IPython.html.services.contents.checkpoints import GenericCheckpointsMixin
+    from IPython.html.services.contents.checkpoints import (
+        GenericCheckpointsMixin,
+    )
     from IPython.html.services.contents.manager import (
         Checkpoints,
     )

--- a/pgcontents/hybridmanager.py
+++ b/pgcontents/hybridmanager.py
@@ -4,8 +4,12 @@ Multi-backend ContentsManager.
 from __future__ import unicode_literals
 
 from six import iteritems
-from IPython.html.services.contents.manager import ContentsManager
-from IPython.utils.traitlets import Dict
+try:
+    from notebook.services.contents.manager import ContentsManager
+    from traitlets import Dict
+except ImportError:
+    from IPython.html.services.contents.manager import ContentsManager
+    from IPython.utils.traitlets import Dict
 from tornado.web import HTTPError
 
 from .api_utils import (

--- a/pgcontents/managerbase.py
+++ b/pgcontents/managerbase.py
@@ -8,12 +8,20 @@ from sqlalchemy import (
 from sqlalchemy.engine.base import Engine
 from tornado.web import HTTPError
 
-from IPython.utils.traitlets import (
-    Bool,
-    Instance,
-    HasTraits,
-    Unicode,
-)
+try:
+    from traitlets import (
+        Bool,
+        Instance,
+        HasTraits,
+        Unicode,
+    )
+except ImportError:
+    from IPython.utils.traitlets import (
+        Bool,
+        Instance,
+        HasTraits,
+        Unicode,
+    )
 
 from .query import ensure_db_user
 

--- a/pgcontents/pgmanager.py
+++ b/pgcontents/pgmanager.py
@@ -18,14 +18,25 @@ PostgreSQL implementation of IPython ContentsManager API.
 from __future__ import unicode_literals
 from itertools import chain
 
-from IPython.nbformat import (
-    from_dict,
-)
-from IPython.utils.traitlets import (
-    Bool,
-    Integer,
-)
-from IPython.html.services.contents.manager import ContentsManager
+try:
+    # ipython >= 4.0
+    from nbformat import (
+        from_dict,
+    )
+    from traitlets import (
+        Bool,
+        Integer,
+    )
+    from notebook.services.contents.manager import ContentsManager
+except ImportError:
+    from IPython.nbformat import (
+        from_dict,
+    )
+    from IPython.utils.traitlets import (
+        Bool,
+        Integer,
+    )
+    from IPython.html.services.contents.manager import ContentsManager
 from tornado import web
 
 from .api_utils import (

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ SQLAlchemy>=1.0.5
 alembic>=0.7.6
 backports.ssl-match-hostname>=3.4.0.2
 certifi>=14.05.14
-ipython==3.2.1
+ipython>=3.2.1
 jsonschema>=2.4.0
 mistune>=0.5.0
 psycopg2>=2.6.1


### PR DESCRIPTION
Imports have been changed. Naming conventions for IPython 4.0 are used first, falling back to IPython 3.2. Perhaps there is a nicer solution?

Tested with IPython 4.0, but not with 3.2.