### PR TITLE
ENH: Add encryption support.

### DIFF
--- a/bin/pgcontents
+++ b/bin/pgcontents
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 from getpass import getuser
 from os import getcwd
-from os.path import join
 import subprocess
 from textwrap import dedent
 
@@ -15,10 +14,6 @@ from pgcontents.constants import (
 from pgcontents.utils.migrate import (
     temp_alembic_ini,
     upgrade,
-)
-from pgcontents.utils.sync import (
-    checkpoint_all,
-    download_checkpoints,
 )
 
 
@@ -113,37 +108,6 @@ def gen_migration(db_url):
             ['alembic', '-c', alembic_ini, 'revision', '--autogenerate']
         )
 
-
-@main.command('download_checkpoints')
-@_db_url
-@_directory
-@_users
-def _download_checkpoints(db_url, directory, users):
-    """
-    Download checkpoints to a directory.
-    """
-    users = users.split(',')
-    if len(users) == 1:
-        download_checkpoints(db_url, directory, users[0])
-    else:
-        for user in users:
-            download_checkpoints(db_url, join(directory, user), user)
-
-
-@main.command('checkpoint_all')
-@_db_url
-@_directory
-@_users
-def _checkpoint_all(db_url, directory, users):
-    """
-    Upload a checkpoint for every file in a directory.
-    """
-    users = users.split(',')
-    if len(users) == 1:
-        checkpoint_all(db_url, directory, users[0])
-    else:
-        for user in users:
-            checkpoint_all(db_url, join(directory, user), user)
 
 if __name__ == "__main__":
     main()

--- a/pgcontents/api_utils.py
+++ b/pgcontents/api_utils.py
@@ -12,7 +12,7 @@ import mimetypes
 import posixpath
 
 from tornado.web import HTTPError
-from .error import PathOutsideRoot
+from .error import CorruptedFile, PathOutsideRoot
 from .utils.ipycompat import reads, writes
 
 NBFORMAT_VERSION = 4
@@ -117,7 +117,10 @@ def reads_base64(nb, as_version=NBFORMAT_VERSION):
     """
     Read a notebook from base64.
     """
-    return reads(b64decode(nb).decode('utf-8'), as_version=as_version)
+    try:
+        return reads(b64decode(nb).decode('utf-8'), as_version=as_version)
+    except Exception as e:
+        raise CorruptedFile(e)
 
 
 def _decode_text_from_base64(path, bcontent):
@@ -161,7 +164,17 @@ def from_b64(path, bcontent, format):
         'text': _decode_text_from_base64,
         None: _decode_unknown_from_base64,
     }
-    content, real_format = decoders[format](path, bcontent)
+
+    try:
+        content, real_format = decoders[format](path, bcontent)
+    except HTTPError:
+        # Pass through HTTPErrors, since we intend for them to bubble all the
+        # way back to the API layer.
+        raise
+    except Exception as e:
+        # Anything else should be wrapped in a CorruptedFile, since it likely
+        # indicates misconfiguration of encryption.
+        raise CorruptedFile(e)
 
     default_mimes = {
         'text': 'text/plain',

--- a/pgcontents/checkpoints.py
+++ b/pgcontents/checkpoints.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 from .api_utils import (
     _decode_unknown_from_base64,
     outside_root_to_404,
-    prefix_dirs,
     reads_base64,
     to_b64,
     writes_base64,
@@ -16,7 +15,6 @@ from .query import (
     delete_remote_checkpoints,
     delete_single_remote_checkpoint,
     get_remote_checkpoint,
-    latest_remote_checkpoints,
     list_remote_checkpoints,
     move_remote_checkpoints,
     purge_remote_checkpoints,
@@ -77,7 +75,7 @@ class PostgresCheckpoints(PostgresManagerMixin,
                 db, self.user_id, path, checkpoint_id,
             )
 
-    def _get_checkpoint(self, checkpoint_id, path):
+    def get_checkpoint_content(self, checkpoint_id, path):
         """Get the content of a checkpoint."""
         with self.engine.begin() as db:
             return get_remote_checkpoint(
@@ -90,7 +88,7 @@ class PostgresCheckpoints(PostgresManagerMixin,
 
     @outside_root_to_404
     def get_notebook_checkpoint(self, checkpoint_id, path):
-        b64_content = self._get_checkpoint(checkpoint_id, path)
+        b64_content = self.get_checkpoint_content(checkpoint_id, path)
         return {
             'type': 'notebook',
             'content': reads_base64(b64_content),
@@ -98,7 +96,7 @@ class PostgresCheckpoints(PostgresManagerMixin,
 
     @outside_root_to_404
     def get_file_checkpoint(self, checkpoint_id, path):
-        b64_content = self._get_checkpoint(checkpoint_id, path)
+        b64_content = self.get_checkpoint_content(checkpoint_id, path)
         content, format = _decode_unknown_from_base64(path, b64_content)
         return {
             'type': 'file',
@@ -135,30 +133,3 @@ class PostgresCheckpoints(PostgresManagerMixin,
         """
         with self.engine.begin() as db:
             purge_remote_checkpoints(db, self.user_id)
-
-    def dump(self, contents_mgr):
-        """
-        Synchronize the state of our database with the specified
-        ContentsManager.
-
-        Gets the most recent checkpoint for each file and passes it to the
-        supplied ContentsManager to be saved.
-        """
-        with self.engine.begin() as db:
-            records = latest_remote_checkpoints(db, self.user_id)
-            for record in records:
-                path = record['path']
-                if not path.endswith('.ipynb'):
-                    self.log.warn('Ignoring non-notebook file: {}', path)
-                    continue
-                for dirname in prefix_dirs(path):
-                    self.log.info("Ensuring directory [%s]" % dirname)
-                    contents_mgr.save(
-                        model={'type': 'directory'},
-                        path=dirname,
-                    )
-                self.log.info("Writing notebook [%s]" % path)
-                contents_mgr.save(
-                    self.get_notebook_checkpoint(record['id'], path),
-                    path,
-                )

--- a/pgcontents/checkpoints.py
+++ b/pgcontents/checkpoints.py
@@ -40,7 +40,14 @@ class PostgresCheckpoints(PostgresManagerMixin,
         """
         b64_content = writes_base64(nb)
         with self.engine.begin() as db:
-            return save_remote_checkpoint(db, self.user_id, path, b64_content)
+            return save_remote_checkpoint(
+                db,
+                self.user_id,
+                path,
+                b64_content,
+                self.crypto.encrypt,
+                self.max_file_size_bytes,
+            )
 
     @outside_root_to_404
     def create_file_checkpoint(self, content, format, path):
@@ -53,7 +60,14 @@ class PostgresCheckpoints(PostgresManagerMixin,
         except ValueError as e:
             self.do_400(str(e))
         with self.engine.begin() as db:
-            return save_remote_checkpoint(db, self.user_id, path, b64_content)
+            return save_remote_checkpoint(
+                db,
+                self.user_id,
+                path,
+                b64_content,
+                self.crypto.encrypt,
+                self.max_file_size_bytes,
+            )
 
     @outside_root_to_404
     def delete_checkpoint(self, checkpoint_id, path):
@@ -71,6 +85,7 @@ class PostgresCheckpoints(PostgresManagerMixin,
                 self.user_id,
                 path,
                 checkpoint_id,
+                self.crypto.decrypt,
             )['content']
 
     @outside_root_to_404

--- a/pgcontents/crypto.py
+++ b/pgcontents/crypto.py
@@ -39,6 +39,15 @@ class FernetEncryption(object):
     -------
     encrypt : callable[bytes -> bytes]
     decrypt : callable[bytes -> bytes]
+
+    Notes
+    -----
+    ``cryptography.fernet.MultiFernet`` can be used instead of a vanilla
+    ``Fernet`` to allow zero-downtime key rotation.
+
+    See Also
+    --------
+    :func:`pgcontents.utils.sync.reencrypt_user`
     """
     __slots__ = ('_fernet',)
 

--- a/pgcontents/crypto.py
+++ b/pgcontents/crypto.py
@@ -1,0 +1,67 @@
+"""
+Interface definition for encryption/decryption plugins for
+PostgresContentsManager.
+
+Encryption backends should raise pgcontents.error.CorruptedFile if they
+encounter an input that they cannot decrypt.
+"""
+from .error import CorruptedFile
+
+
+class NoEncryption(object):
+    """
+    No-op encryption backend.
+
+    encrypt() and decrypt() simply return their inputs.
+
+    Methods
+    -------
+    encrypt : callable[bytes -> bytes]
+    decrypt : callable[bytes -> bytes]
+    """
+    def encrypt(self, b):
+        return b
+
+    def decrypt(self, b):
+        return b
+
+
+class FernetEncryption(object):
+    """
+    Notebook encryption using cryptography.fernet for symmetric-key encryption.
+
+    Parameters
+    ----------
+    fernet : cryptography.fernet.Fernet
+       The Fernet object to use for encryption.
+
+    Methods
+    -------
+    encrypt : callable[bytes -> bytes]
+    decrypt : callable[bytes -> bytes]
+    """
+    __slots__ = ('_fernet',)
+
+    def __init__(self, fernet):
+        self._fernet = fernet
+
+    def encrypt(self, s):
+        return self._fernet.encrypt(s)
+
+    def decrypt(self, s):
+        try:
+            return self._fernet.decrypt(s)
+        except Exception as e:
+            raise CorruptedFile(e)
+
+    def __copy__(self, memo):
+        # Any value that appears in an IPython/Jupyter Config object needs to
+        # be deepcopy-able. Cryptography's Fernet objects aren't deepcopy-able,
+        # so we copy our underlying state to a new FernetEncryption object.
+        return FernetEncryption(self._fernet)
+
+    def __deepcopy__(self, memo):
+        # Any value that appears in an IPython/Jupyter Config object needs to
+        # be deepcopy-able. Cryptography's Fernet objects aren't deepcopy-able,
+        # so we copy our underlying state to a new FernetEncryption object.
+        return FernetEncryption(self._fernet)

--- a/pgcontents/error.py
+++ b/pgcontents/error.py
@@ -37,3 +37,7 @@ class FileTooLarge(Exception):
 
 class RenameRoot(Exception):
     pass
+
+
+class CorruptedFile(Exception):
+    pass

--- a/pgcontents/managerbase.py
+++ b/pgcontents/managerbase.py
@@ -8,15 +8,16 @@ from sqlalchemy import (
 from sqlalchemy.engine.base import Engine
 from tornado.web import HTTPError
 
+from .constants import UNLIMITED
+from .crypto import NoEncryption
 from .query import ensure_db_user
-from .utils.ipycompat import Bool, Instance, HasTraits, Unicode
+from .utils.ipycompat import Any, Bool, Instance, Integer, HasTraits, Unicode
 
 
 class PostgresManagerMixin(HasTraits):
     """
-    Shared  for Postgres-backed ContentsManagers.
+    Shared behavior for Postgres-backed ContentsManagers.
     """
-
     db_url = Unicode(
         default_value="postgresql://{user}@/pgcontents".format(
             user=getuser(),
@@ -36,6 +37,22 @@ class PostgresManagerMixin(HasTraits):
         default_value=True,
         config=True,
         help="Create a user for user_id automatically?",
+    )
+
+    max_file_size_bytes = Integer(
+        default_value=UNLIMITED,
+        config=True,
+        help="Maximum size in bytes of a file that will be saved.",
+    )
+
+    crypto = Any(
+        default_value=NoEncryption(),
+        allow_none=False,
+        config=True,
+        help=(
+            "Object with encrypt() and decrypt() methods to "
+            "call on data entering/exiting the database.",
+        )
     )
 
     engine = Instance(Engine)

--- a/pgcontents/managerbase.py
+++ b/pgcontents/managerbase.py
@@ -58,7 +58,7 @@ class PostgresManagerMixin(HasTraits):
     engine = Instance(Engine)
 
     def _engine_default(self):
-        return create_engine(self.db_url, echo=True)
+        return create_engine(self.db_url, echo=False)
 
     def __init__(self, *args, **kwargs):
         super(PostgresManagerMixin, self).__init__(*args, **kwargs)

--- a/pgcontents/managerbase.py
+++ b/pgcontents/managerbase.py
@@ -58,7 +58,7 @@ class PostgresManagerMixin(HasTraits):
     engine = Instance(Engine)
 
     def _engine_default(self):
-        return create_engine(self.db_url)
+        return create_engine(self.db_url, echo=True)
 
     def __init__(self, *args, **kwargs):
         super(PostgresManagerMixin, self).__init__(*args, **kwargs)

--- a/pgcontents/pgmanager.py
+++ b/pgcontents/pgmanager.py
@@ -66,14 +66,14 @@ class PostgresContentsManager(PostgresManagerMixin, ContentsManager):
     """
     create_directory_on_startup = Bool(
         config=True,
-        help="Create a user for user_id automatically?",
+        help="Create a root directory automatically?",
     )
 
     def _checkpoints_class_default(self):
         return PostgresCheckpoints
 
     def _checkpoints_kwargs_default(self):
-        kw = super(PostgresContentsManager, self)._checkpoint_kwargs_default()
+        kw = super(PostgresContentsManager, self)._checkpoints_kwargs_default()
         kw.update({
             'create_user_on_startup': self.create_user_on_startup,
             'crypto': self.crypto,

--- a/pgcontents/pgmanager.py
+++ b/pgcontents/pgmanager.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-PostgreSQL implementation of IPython ContentsManager API.
+PostgreSQL implementation of IPython/Jupyter ContentsManager API.
 """
 from __future__ import unicode_literals
 from itertools import chain
@@ -30,8 +30,8 @@ from .api_utils import (
     writes_base64,
 )
 from .checkpoints import PostgresCheckpoints
-from .constants import UNLIMITED
 from .error import (
+    CorruptedFile,
     DirectoryExists,
     DirectoryNotEmpty,
     FileExists,
@@ -56,7 +56,7 @@ from .query import (
     rename_file,
     save_file,
 )
-from .utils.ipycompat import Bool, ContentsManager, Integer, from_dict
+from .utils.ipycompat import Bool, ContentsManager, from_dict
 
 
 class PostgresContentsManager(PostgresManagerMixin, ContentsManager):
@@ -64,12 +64,6 @@ class PostgresContentsManager(PostgresManagerMixin, ContentsManager):
     ContentsManager that persists to a postgres database rather than to the
     local filesystem.
     """
-    max_file_size_bytes = Integer(
-        default_value=UNLIMITED,
-        config=True,
-        help="Maximum size in bytes of a file that will be saved.",
-    )
-
     create_directory_on_startup = Bool(
         config=True,
         help="Create a user for user_id automatically?",
@@ -79,14 +73,14 @@ class PostgresContentsManager(PostgresManagerMixin, ContentsManager):
         return PostgresCheckpoints
 
     def _checkpoints_kwargs_default(self):
-        kw = super(PostgresContentsManager, self)._checkpoints_kwargs_default()
-        kw.update(
-            {
-                'db_url': self.db_url,
-                'user_id': self.user_id,
-                'create_user_on_startup': self.create_user_on_startup,
-            }
-        )
+        kw = super(PostgresContentsManager, self)._checkpoint_kwargs_default()
+        kw.update({
+            'create_user_on_startup': self.create_user_on_startup,
+            'crypto': self.crypto,
+            'db_url': self.db_url,
+            'max_file_size_bytes': self.max_file_size_bytes,
+            'user_id': self.user_id,
+        })
         return kw
 
     def _create_directory_on_startup_default(self):
@@ -149,7 +143,15 @@ class PostgresContentsManager(PostgresManagerMixin, ContentsManager):
             }[type]
         except KeyError:
             raise ValueError("Unknown type passed: '{}'".format(type))
-        return fn(path=path, content=content, format=format)
+
+        try:
+            return fn(path=path, content=content, format=format)
+        except CorruptedFile as e:
+            self.log.error(
+                u'Corrupted file encountered at path %r. %s',
+                path, e, exc_info=True,
+            )
+            self.do_500("Unable to read stored content at path %r." % path)
 
     @outside_root_to_404
     def get_file_id(self, path):
@@ -171,7 +173,13 @@ class PostgresContentsManager(PostgresManagerMixin, ContentsManager):
         """
         with self.engine.begin() as db:
             try:
-                record = get_file(db, self.user_id, path, content)
+                record = get_file(
+                    db,
+                    self.user_id,
+                    path,
+                    content,
+                    self.crypto.decrypt,
+                )
             except NoSuchFile:
                 self.no_such_entity(path)
 
@@ -265,7 +273,13 @@ class PostgresContentsManager(PostgresManagerMixin, ContentsManager):
     def _get_file(self, path, content, format):
         with self.engine.begin() as db:
             try:
-                record = get_file(db, self.user_id, path, content)
+                record = get_file(
+                    db,
+                    self.user_id,
+                    path,
+                    content,
+                    self.crypto.decrypt,
+                )
             except NoSuchFile:
                 if self.dir_exists(path):
                     # TODO: It's awkward/expensive to have to check this to
@@ -288,6 +302,7 @@ class PostgresContentsManager(PostgresManagerMixin, ContentsManager):
             self.user_id,
             path,
             writes_base64(nb_contents),
+            self.crypto.encrypt,
             self.max_file_size_bytes,
         )
         # It's awkward that this writes to the model instead of returning.
@@ -303,6 +318,7 @@ class PostgresContentsManager(PostgresManagerMixin, ContentsManager):
             self.user_id,
             path,
             to_b64(model['content'], model.get('format', None)),
+            self.crypto.encrypt,
             self.max_file_size_bytes,
         )
         return None

--- a/pgcontents/tests/test_hybrid_manager.py
+++ b/pgcontents/tests/test_hybrid_manager.py
@@ -24,6 +24,7 @@ from pgcontents.pgmanager import PostgresContentsManager
 from .test_pgmanager import PostgresContentsManagerTestCase
 from .utils import (
     assertRaisesHTTPError,
+    make_fernet,
     remigrate_test_schema,
     TEST_DB_URL,
 )
@@ -67,9 +68,11 @@ class FileTestCase(TestContentsManager):
 class PostgresTestCase(PostgresContentsManagerTestCase):
 
     def setUp(self):
+        self.crypto = make_fernet()
         self._pgmanager = PostgresContentsManager(
             user_id='test',
             db_url=TEST_DB_URL,
+            crypto=self.crypto,
         )
         self._pgmanager.ensure_user()
         self._pgmanager.ensure_root_directory()

--- a/pgcontents/tests/test_pgcontents_api.py
+++ b/pgcontents/tests/test_pgcontents_api.py
@@ -27,6 +27,7 @@ from IPython.utils.tempdir import TemporaryDirectory
 from requests import HTTPError
 
 from ..constants import UNLIMITED
+from ..crypto import FernetEncryption, NoEncryption
 from ..hybridmanager import HybridContentsManager
 from ..pgmanager import (
     PostgresContentsManager,
@@ -43,6 +44,7 @@ from ..query import (
 )
 from .utils import (
     clear_test_db,
+    make_fernet,
     _norm_unicode,
     remigrate_test_schema,
     TEST_DB_URL,
@@ -162,12 +164,20 @@ class _APITestBase(APITest):
         )
 
 
-class PostgresContentsAPITest(_APITestBase):
-
+def postgres_contents_config():
+    """
+    Shared setup code for PostgresContentsAPITest and subclasses.
+    """
     config = Config()
     config.NotebookApp.contents_manager_class = PostgresContentsManager
     config.PostgresContentsManager.user_id = 'test'
     config.PostgresContentsManager.db_url = TEST_DB_URL
+    return config
+
+
+class PostgresContentsAPITest(_APITestBase):
+
+    config = postgres_contents_config()
 
     # Don't support hidden directories.
     hidden_dirs = []
@@ -196,6 +206,10 @@ class PostgresContentsAPITest(_APITestBase):
     def engine(self):
         return self.pg_manager.engine
 
+    @property
+    def crypto(self):
+        return self.pg_manager.crypto
+
     # Superclass method overrides.
     def make_dir(self, api_path):
         with self.engine.begin() as db:
@@ -208,16 +222,31 @@ class PostgresContentsAPITest(_APITestBase):
                 self.user_id,
                 api_path,
                 b64encode(txt.encode('utf-8')),
+                self.crypto.encrypt,
                 UNLIMITED,
             )
 
     def make_blob(self, api_path, blob):
         with self.engine.begin() as db:
-            save_file(db, self.user_id, api_path, b64encode(blob), UNLIMITED)
+            save_file(
+                db,
+                self.user_id,
+                api_path,
+                b64encode(blob),
+                self.crypto.encrypt,
+                UNLIMITED,
+            )
 
     def make_nb(self, api_path, nb):
         with self.engine.begin() as db:
-            save_file(db, self.user_id, api_path, writes_base64(nb), UNLIMITED)
+            save_file(
+                db,
+                self.user_id,
+                api_path,
+                writes_base64(nb),
+                self.crypto.encrypt,
+                UNLIMITED,
+            )
 
     def delete_dir(self, api_path, db=None):
         if self.isdir(api_path):
@@ -257,9 +286,28 @@ class PostgresContentsAPITest(_APITestBase):
     def test_checkpoints_separate_root(self):
         pass
 
+    def test_crypto_types(self):
+        self.assertIsInstance(self.pg_manager.crypto, NoEncryption)
+        self.assertIsInstance(self.pg_manager.checkpoints.crypto, NoEncryption)
+
+
+class EncryptedPostgresContentsAPITest(PostgresContentsAPITest):
+    config = postgres_contents_config()
+    # The key for this needs to be a b64-encoded 32-byte string.
+    config.PostgresContentsManager.crypto = make_fernet()
+
+    def test_crypto_types(self):
+        self.assertIsInstance(self.pg_manager.crypto, FernetEncryption)
+        self.assertIsInstance(
+            self.pg_manager.checkpoints.crypto,
+            FernetEncryption,
+        )
+
 
 class PostgresContentsFileCheckpointsAPITest(PostgresContentsAPITest):
-
+    """
+    Test using PostgresContents and FileCheckpoints.
+    """
     config = Config()
     config.NotebookApp.contents_manager_class = PostgresContentsManager
     config.PostgresContentsManager.checkpoints_class = GenericFileCheckpoints
@@ -281,16 +329,24 @@ class PostgresContentsFileCheckpointsAPITest(PostgresContentsAPITest):
         cls.td.cleanup()
 
 
-class PostgresCheckpointsAPITest(_APITestBase):
+def postgres_checkpoints_config():
     """
-    Test using PostgresCheckpoints with the built-in FileContentsManager.
+    Shared setup for PostgresCheckpointsAPITest and subclasses.
     """
-
     config = Config()
     config.NotebookApp.contents_manager_class = FileContentsManager
     config.ContentsManager.checkpoints_class = PostgresCheckpoints
     config.PostgresCheckpoints.user_id = 'test'
     config.PostgresCheckpoints.db_url = TEST_DB_URL
+
+    return config
+
+
+class PostgresCheckpointsAPITest(_APITestBase):
+    """
+    Test using PostgresCheckpoints with the built-in FileContentsManager.
+    """
+    config = postgres_checkpoints_config()
 
     @property
     def checkpoints(self):
@@ -312,6 +368,14 @@ class PostgresCheckpointsAPITest(_APITestBase):
         pass
 
 
+class EncryptedPostgresCheckpointsAPITest(PostgresCheckpointsAPITest):
+    config = postgres_checkpoints_config()
+    config.PostgresCheckpoints.crypto = make_fernet()
+
+    def test_crypto_types(self):
+        self.assertIsInstance(self.checkpoints.crypto, FernetEncryption)
+
+
 class HybridContentsPGRootAPITest(PostgresContentsAPITest):
     """
     Test using a HybridContentsManager splitting between files and Postgres.
@@ -320,19 +384,23 @@ class HybridContentsPGRootAPITest(PostgresContentsAPITest):
     files_test_cls = APITest
 
     @classmethod
-    def setup_class(cls):
-        cls.td = TemporaryDirectory()
-
-        cls.config = Config()
-        cls.config.NotebookApp.contents_manager_class = HybridContentsManager
-        cls.config.HybridContentsManager.manager_classes = {
+    def make_config(cls, td):
+        config = Config()
+        config.NotebookApp.contents_manager_class = HybridContentsManager
+        config.HybridContentsManager.manager_classes = {
             '': PostgresContentsManager,
             cls.files_prefix: FileContentsManager,
         }
-        cls.config.HybridContentsManager.manager_kwargs = {
+        config.HybridContentsManager.manager_kwargs = {
             '': {'user_id': 'test', 'db_url': TEST_DB_URL},
-            cls.files_prefix: {'root_dir': cls.td.name},
+            cls.files_prefix: {'root_dir': td.name},
         }
+        return config
+
+    @classmethod
+    def setup_class(cls):
+        cls.td = TemporaryDirectory()
+        cls.config = cls.make_config(cls.td)
         super(HybridContentsPGRootAPITest, cls).setup_class()
 
     @property
@@ -379,6 +447,7 @@ class HybridContentsPGRootAPITest(PostgresContentsAPITest):
         l[method_name] = __api_path_dispatch(method_name)
     del __methods_to_multiplex
     del __api_path_dispatch
+    del l
 
     # Override to not delete the root of the file subsystem.
     def test_delete_dirs(self):
@@ -399,6 +468,23 @@ class HybridContentsPGRootAPITest(PostgresContentsAPITest):
         self.assertEqual(len(listing), 1)
         self.assertEqual(listing[0]['path'], self.files_prefix)
 
+
+class EncryptedHybridContentsAPITest(HybridContentsPGRootAPITest):
+
+    @classmethod
+    def make_config(cls, td):
+        config = super(EncryptedHybridContentsAPITest, cls).make_config(td)
+        config.HybridContentsManager.manager_kwargs['']['crypto'] = (
+            make_fernet()
+        )
+        return config
+
+    def test_crypto_types(self):
+        self.assertIsInstance(self.pg_manager.crypto, FernetEncryption)
+        self.assertIsInstance(
+            self.pg_manager.checkpoints.crypto,
+            FernetEncryption,
+        )
 
 # This needs to be removed or else we'll run the main IPython tests as well.
 del APITest

--- a/pgcontents/tests/test_pgcontents_api.py
+++ b/pgcontents/tests/test_pgcontents_api.py
@@ -293,7 +293,6 @@ class PostgresContentsAPITest(_APITestBase):
 
 class EncryptedPostgresContentsAPITest(PostgresContentsAPITest):
     config = postgres_contents_config()
-    # The key for this needs to be a b64-encoded 32-byte string.
     config.PostgresContentsManager.crypto = make_fernet()
 
     def test_crypto_types(self):

--- a/pgcontents/tests/test_synchronization.py
+++ b/pgcontents/tests/test_synchronization.py
@@ -18,6 +18,7 @@ from IPython.utils.tempdir import TemporaryDirectory
 from six import iteritems
 
 from ..checkpoints import PostgresCheckpoints
+from ..crypto import NoEncryption
 from .utils import (
     clear_test_db,
     _norm_unicode,
@@ -95,6 +96,7 @@ class TestUploadDownload(TestCase):
                 self.checkpoints.db_url,
                 td,
                 user='test',
+                crypto=NoEncryption(),
             )
 
             fm = FileContentsManager(root_dir=td)

--- a/pgcontents/tests/test_synchronization.py
+++ b/pgcontents/tests/test_synchronization.py
@@ -142,11 +142,24 @@ class TestReEncryption(TestCase):
         crypto1_factory = {user_id: crypto1}.__getitem__
         crypto2_factory = {user_id: crypto2}.__getitem__
 
-        reencrypt_all_users(engine, no_crypto_factory, crypto1_factory, logger)
-        check_reencryption(no_crypto_manager, manager1)
+        # Verify that reencryption is idempotent:
+        for _ in range(2):
+            reencrypt_all_users(
+                engine,
+                no_crypto_factory,
+                crypto1_factory,
+                logger,
+            )
+            check_reencryption(no_crypto_manager, manager1)
 
-        reencrypt_all_users(engine, crypto1_factory, crypto2_factory, logger)
-        check_reencryption(manager1, manager2)
+        for _ in range(2):
+            reencrypt_all_users(
+                engine,
+                crypto1_factory,
+                crypto2_factory,
+                logger,
+            )
+            check_reencryption(manager1, manager2)
 
         with self.assertRaises(ValueError):
             # Using reencrypt_all_users with a no-encryption target isn't

--- a/pgcontents/tests/utils.py
+++ b/pgcontents/tests/utils.py
@@ -4,6 +4,7 @@ Utilities for testing.
 """
 from __future__ import unicode_literals
 from contextlib import contextmanager
+from cryptography.fernet import Fernet
 from getpass import getuser
 from itertools import starmap
 import posixpath
@@ -15,6 +16,7 @@ from sqlalchemy import create_engine
 from tornado.web import HTTPError
 
 from ..api_utils import api_path_join
+from ..crypto import FernetEncryption
 from ..schema import metadata
 from ..utils.ipycompat import (
     new_code_cell,
@@ -27,6 +29,10 @@ from ..utils.migrate import upgrade
 TEST_DB_URL = "postgresql://{user}@/pgcontents_testing".format(
     user=getuser(),
 )
+
+
+def make_fernet():
+    return FernetEncryption(Fernet(Fernet.generate_key()))
 
 
 def _norm_unicode(s):

--- a/pgcontents/utils/ipycompat.py
+++ b/pgcontents/utils/ipycompat.py
@@ -37,6 +37,7 @@ if IPY3:
     )
     from IPython.nbformat.v4.rwbase import strip_transient
     from IPython.utils.traitlets import (
+        Any,
         Bool,
         Dict,
         Instance,
@@ -71,6 +72,7 @@ else:
     )
     from nbformat.v4.rwbase import strip_transient
     from traitlets import (
+        Any,
         Bool,
         Dict,
         Instance,
@@ -81,6 +83,7 @@ else:
 
 __all__ = [
     'APITest',
+    'Any',
     'Bool',
     'Checkpoints',
     'Config',

--- a/pgcontents/utils/sync.py
+++ b/pgcontents/utils/sync.py
@@ -24,7 +24,7 @@ def create_user(db_url, user):
     )
 
 
-def download_checkpoints(db_url, directory, user):
+def download_checkpoints(db_url, directory, user, crypto):
     """
     Download users' most recent checkpoints to the given directory.
     """
@@ -37,6 +37,7 @@ def download_checkpoints(db_url, directory, user):
         db_url=db_url,
         user_id=user,
         create_user_on_startup=False,
+        crypto=crypto,
     )
     cp_mgr.dump(contents_mgr)
     print("Done")

--- a/pgcontents/utils/sync.py
+++ b/pgcontents/utils/sync.py
@@ -6,11 +6,11 @@ from __future__ import (
     unicode_literals,
 )
 
-
-from IPython.utils.path import ensure_dir_exists
-
 from ..checkpoints import PostgresCheckpoints
-from ..utils.ipycompat import FileContentsManager
+from ..query import (
+    list_users,
+    reencrypt_user_content,
+)
 
 
 def create_user(db_url, user):
@@ -22,50 +22,6 @@ def create_user(db_url, user):
         user_id=user,
         create_user_on_startup=True,
     )
-
-
-def download_checkpoints(db_url, directory, user, crypto):
-    """
-    Download users' most recent checkpoints to the given directory.
-    """
-    print("Synchronizing user {user} to {directory}".format(
-        user=user, directory=directory,
-    ))
-    ensure_dir_exists(directory)
-    contents_mgr = FileContentsManager(root_dir=directory)
-    cp_mgr = PostgresCheckpoints(
-        db_url=db_url,
-        user_id=user,
-        create_user_on_startup=False,
-        crypto=crypto,
-    )
-    cp_mgr.dump(contents_mgr)
-    print("Done")
-
-
-def checkpoint_all(db_url, directory, user):
-    """
-    Upload the current state of a directory for each user.
-    """
-    print("Checkpointing directory {directory} for user {user}".format(
-        directory=directory, user=user,
-    ))
-
-    cp_mgr = PostgresCheckpoints(
-        db_url=db_url,
-        user_id=user,
-        create_user_on_startup=False,
-    )
-    contents_mgr = FileContentsManager(
-        root_dir=directory,
-        checkpoints=cp_mgr,
-    )
-    cps = {}
-    for dirname, subdirs, files in walk(contents_mgr):
-        for fname in files:
-            if fname.endswith('.ipynb'):
-                cps[fname] = contents_mgr.create_checkpoint(fname)
-    return cps
 
 
 def _separate_dirs_files(models):
@@ -108,3 +64,67 @@ def walk_dirs(mgr, dirs):
         if dirs:
             for entry in walk_dirs(mgr, dirs):
                 yield entry
+
+
+def walk_files(mgr):
+    """
+    Iterate over all files visible to ``mgr``.
+    """
+    for dir_, subdirs, files in walk_files(mgr):
+        for file_ in files:
+            yield file_
+
+
+def all_user_ids(engine):
+    """
+    Get a list of user_ids from an engine.
+    """
+    with engine.begin() as db:
+        return [row[0] for row in list_users(db)]
+
+
+def reencrypt_all_users(engine,
+                        old_crypto_factory,
+                        new_crypto_factory,
+                        logger):
+    """
+    Re-encrypt data for all users.
+
+    Parameters
+    ----------
+    engine : SQLAlchemy.engine
+        Engine encapsulating database connections.
+    old_crypto_factory : function[str -> Any]
+        A function from user_id to an object providing the interface required
+        by PostgresContentsManager.crypto.  Results of this will be used for
+        decryption of existing database content.
+    new_crypto_factory : function[str -> Any]
+        A function from user_id to an object providing the interface required
+        by PostgresContentsManager.crypto.  Results of this will be used for
+        re-encryption of database content.
+    logger : logging.Logger, optional
+        A logger to user during re-encryption.
+    """
+    logger.info("Beginning re-encryption for all users.")
+    for user_id in all_user_ids(engine):
+        reencrypt_user(
+            engine,
+            user_id,
+            old_crypto=old_crypto_factory(user_id),
+            new_crypto=new_crypto_factory(user_id),
+            logger=logger,
+        )
+    logger.info("Finished re-encryption for all users.")
+
+
+def reencrypt_user(engine, user_id, old_crypto, new_crypto, logger):
+    """
+    Re-encrypt all files and checkpoints for a single user.
+    """
+    reencrypt_user_content(
+        engine,
+        user_id,
+        old_crypto.decrypt,
+        new_crypto.encrypt,
+        logger=logger,
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 SQLAlchemy>=1.0.5
 alembic>=0.7.6
 click>=3.3
+cryptography>=1.4
 psycopg2>=2.6.1
 requests>=2.7.0
 six>=1.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-tox>=2.3
 SQLAlchemy>=1.0.5
 alembic>=0.7.6
+click>=3.3
 psycopg2>=2.6.1
 requests>=2.7.0
 six>=1.9.0
-click>=3.3
+tox>=2.3

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,10 @@ deps =
     py{27,34}-ipython3: .[test,ipy3]
     py{27,34}-ipython4: .[test,ipy4]
     flake8: flake8
+    notest: .[ipy4]
 
 commands =
     py{27,34}-ipython{3,4}: -createdb pgcontents_testing
     py{27,34}-ipython{3,4}: nosetests pgcontents/tests
     flake8: flake8 pgcontents
+    notest: python -c 'from pgcontents.utils.ipycompat import *'


### PR DESCRIPTION
Adds new configurable ``crypto`` attributes to PostgresContentsManager
and PostgresCheckpoints.  ``crypto`` objects must provide ``encrypt``
and ``decrypt`` methods, which will be called on data being written to
and read from the database, respectively.

The default ``crypto`` implementation is ``NoEncryption``, which returns
its inputs unchanged.

The built-in ``crypto`` implementation is ``FernetEncryption``, which
uses ``cryptography.fernet`` to implement symmetric-key encryption of
all notebooks and files in the database.