### PR TITLE
ENH: Order `_generate_notebooks` output by datetime

### DIFF
--- a/pgcontents/crypto.py
+++ b/pgcontents/crypto.py
@@ -221,15 +221,18 @@ def single_password_crypto_factory(password):
     The factory here returns a ``FernetEncryption`` that uses a key derived
     from ``password`` and salted with the supplied user_id.
     """
+    @MemoizedCryptoFactory
     def factory(user_id):
         return FernetEncryption(
             Fernet(derive_single_fernet_key(password, user_id))
         )
-    return MemoizedCryptoFactory(factory)
+    return factory
 
 
 class MemoizedCryptoFactory(object):
-
+    """
+    Decorator adding memoization to a crypto_factory.
+    """
     def __init__(self, crypto_factory):
         self._crypto_factory = crypto_factory
         self._cryptos = {}

--- a/pgcontents/crypto.py
+++ b/pgcontents/crypto.py
@@ -225,4 +225,19 @@ def single_password_crypto_factory(password):
         return FernetEncryption(
             Fernet(derive_single_fernet_key(password, user_id))
         )
-    return factory
+    return MemoizedCryptoFactory(factory)
+
+
+class MemoizedCryptoFactory(object):
+
+    def __init__(self, crypto_factory):
+        self._crypto_factory = crypto_factory
+        self._cryptos = {}
+
+    def __call__(self, user_id):
+        try:
+            return self._cryptos[user_id]
+        except KeyError:
+            crypto = self._crypto_factory(user_id)
+            self._cryptos[user_id] = crypto
+            return crypto

--- a/pgcontents/query.py
+++ b/pgcontents/query.py
@@ -553,6 +553,8 @@ def generate_files(engine, crypto_factory, min_dt=None, max_dt=None):
     """
     Create a generator of decrypted files.
 
+    Files are yielded in ascending order of their timestamp.
+
     This function selects all current notebooks (optionally, falling within a
     datetime range), decrypts them, and returns a generator yielding dicts,
     each containing a decoded notebook and metadata including the user,
@@ -731,6 +733,8 @@ def purge_remote_checkpoints(db, user_id):
 def generate_checkpoints(engine, crypto_factory, min_dt=None, max_dt=None):
     """
     Create a generator of decrypted remote checkpoints.
+
+    Checkpoints are yielded in ascending order of their timestamp.
 
     This function selects all notebook checkpoints (optionally, falling within
     a datetime range), decrypts them, and returns a generator yielding dicts,

--- a/pgcontents/query.py
+++ b/pgcontents/query.py
@@ -23,7 +23,6 @@ from .api_utils import (
     to_api_path,
 )
 from .constants import UNLIMITED
-from .crypto import MemoizedCryptoFactory
 from .db_utils import (
     ignore_unique_violation,
     is_unique_violation,
@@ -785,9 +784,6 @@ def _generate_notebooks(table, timestamp_column,
     max_dt : datetime.datetime, optional
         Last modified datetime at and after which a file will be excluded.
     """
-    if not isinstance(crypto_factory, MemoizedCryptoFactory):
-        crypto_factory = MemoizedCryptoFactory(crypto_factory)
-
     where_conds = []
     if min_dt is not None:
         where_conds.append(timestamp_column >= min_dt)

--- a/pgcontents/query.py
+++ b/pgcontents/query.py
@@ -571,12 +571,8 @@ def generate_files(engine, crypto_factory, min_dt=None, max_dt=None):
     max_dt : datetime.datetime, optional
         Last modified datetime at and after which a file will be excluded.
     """
-    where_conds = []
-    if min_dt is not None:
-        where_conds.append(files.c.created_at >= min_dt)
-    if max_dt is not None:
-        where_conds.append(files.c.created_at < max_dt)
-    return _generate_notebooks(files, engine, where_conds, crypto_factory)
+    return _generate_notebooks(files, files.c.created_at,
+                               engine, crypto_factory, min_dt, max_dt)
 
 
 # =======================================
@@ -754,38 +750,59 @@ def generate_checkpoints(engine, crypto_factory, min_dt=None, max_dt=None):
     max_dt : datetime.datetime, optional
         Last modified datetime at and after which a file will be excluded.
     """
-    where_conds = []
-    if min_dt is not None:
-        where_conds.append(remote_checkpoints.c.last_modified >= min_dt)
-    if max_dt is not None:
-        where_conds.append(remote_checkpoints.c.last_modified < max_dt)
     return _generate_notebooks(remote_checkpoints,
-                               engine, where_conds, crypto_factory)
+                               remote_checkpoints.c.last_modified,
+                               engine, crypto_factory, min_dt, max_dt)
 
 
 # ====================
 # Files or Checkpoints
 # ====================
-def _generate_notebooks(table, engine, where_conds, crypto_factory):
+def _generate_notebooks(table, timestamp_column,
+                        engine, crypto_factory, min_dt, max_dt):
     """
     See docstrings for `generate_files` and `generate_checkpoints`.
-    `where_conds` should be a list of SQLAlchemy expressions, which are used as
-    the conditions for WHERE clauses on the SELECT queries to the database.
+
+    Parameters
+    ----------
+    table : SQLAlchemy.Table
+        Table to fetch notebooks from, `files` or `remote_checkpoints.
+    timestamp_column : SQLAlchemy.Column
+        `table`'s column storing timestamps, `created_at` or `last_modified`.
+    engine : SQLAlchemy.engine
+        Engine encapsulating database connections.
+    crypto_factory : function[str -> Any]
+        A function from user_id to an object providing the interface required
+        by PostgresContentsManager.crypto.  Results of this will be used for
+        decryption of the selected notebooks.
+    min_dt : datetime.datetime, optional
+        Minimum last modified datetime at which a file will be included.
+    max_dt : datetime.datetime, optional
+        Last modified datetime at and after which a file will be excluded.
     """
+    where_conds = []
+    if min_dt is not None:
+        where_conds.append(timestamp_column >= min_dt)
+    if max_dt is not None:
+        where_conds.append(timestamp_column < max_dt)
+
     # Query for notebooks satisfying the conditions.
-    query = select([table]).order_by(table.c.user_id)
+    query = select([table]).order_by(timestamp_column)
     for cond in where_conds:
         query = query.where(cond)
     result = engine.execute(query)
 
+    decrypt_funcs = {}  # Memoize decrypt functions by user
+
     # Decrypt each notebook and yield the result.
-    last_user_id = None
     for nb_row in result:
-        # The decrypt function depends on the user, so if the user is the same
-        # then the decrypt function carries over.
-        if nb_row['user_id'] != last_user_id:
-            decrypt_func = crypto_factory(nb_row['user_id']).decrypt
-            last_user_id = nb_row['user_id']
+        # The decrypt function depends on the user
+        user_id = nb_row['user_id']
+        try:
+            decrypt_func = decrypt_funcs[user_id]
+        except KeyError:
+            decrypt_func = crypto_factory(user_id).decrypt
+            decrypt_funcs[user_id] = decrypt_func
 
         nb_dict = to_dict_with_content(table.c, nb_row, decrypt_func)
         if table is files:
@@ -798,7 +815,7 @@ def _generate_notebooks(table, engine, where_conds, crypto_factory):
         # here as well.
         yield {
             'id': nb_dict['id'],
-            'user_id': nb_dict['user_id'],
+            'user_id': user_id,
             'path': to_api_path(nb_dict['path']),
             'last_modified': nb_dict['last_modified'],
             'content': reads_base64(nb_dict['content']),

--- a/pgcontents/tests/test_encryption.py
+++ b/pgcontents/tests/test_encryption.py
@@ -1,56 +1,83 @@
 """
 Tests for notebook encryption utilities.
 """
+from unittest import TestCase
+
 from cryptography.fernet import Fernet
 
 from ..crypto import (
     derive_fallback_fernet_keys,
     FallbackCrypto,
     FernetEncryption,
+    MemoizedCryptoFactory,
     NoEncryption,
     single_password_crypto_factory,
 )
 
 
-def test_fernet_derivation():
-    pws = [u'currentpassword', u'oldpassword', None]
+class TestEncryption(TestCase):
 
-    # This must be Unicode, so we use the `u` prefix to support py2.
-    user_id = u'4e322fa200fffd0001000001'
+    def test_fernet_derivation(self):
+        pws = [u'currentpassword', u'oldpassword', None]
 
-    current_crypto = single_password_crypto_factory(pws[0])(user_id)
-    old_crypto = single_password_crypto_factory(pws[1])(user_id)
+        # This must be Unicode, so we use the `u` prefix to support py2.
+        user_id = u'4e322fa200fffd0001000001'
 
-    def make_single_key_crypto(key):
-        if key is None:
-            return NoEncryption()
-        return FernetEncryption(Fernet(key.encode('ascii')))
+        current_crypto = single_password_crypto_factory(pws[0])(user_id)
+        old_crypto = single_password_crypto_factory(pws[1])(user_id)
 
-    multi_fernet_crypto = FallbackCrypto(
-        [make_single_key_crypto(k)
-         for k in derive_fallback_fernet_keys(pws, user_id)]
-    )
+        def make_single_key_crypto(key):
+            if key is None:
+                return NoEncryption()
+            return FernetEncryption(Fernet(key.encode('ascii')))
 
-    data = b'ayy lmao'
+        multi_fernet_crypto = FallbackCrypto(
+            [make_single_key_crypto(k)
+             for k in derive_fallback_fernet_keys(pws, user_id)]
+        )
 
-    # Data encrypted with the current key.
-    encrypted_data_current = current_crypto.encrypt(data)
-    assert encrypted_data_current != data
-    assert current_crypto.decrypt(encrypted_data_current) == data
+        data = b'ayy lmao'
 
-    # Data encrypted with the old key.
-    encrypted_data_old = old_crypto.encrypt(data)
-    assert encrypted_data_current != data
-    assert old_crypto.decrypt(encrypted_data_old) == data
+        # Data encrypted with the current key.
+        encrypted_data_current = current_crypto.encrypt(data)
+        self.assertNotEqual(encrypted_data_current, data)
+        self.assertEqual(current_crypto.decrypt(encrypted_data_current), data)
 
-    # The single fernet with the first key should be able to decrypt the
-    # multi-fernet's encrypted data.
+        # Data encrypted with the old key.
+        encrypted_data_old = old_crypto.encrypt(data)
+        self.assertNotEqual(encrypted_data_current, data)
+        self.assertEqual(old_crypto.decrypt(encrypted_data_old), data)
 
-    assert current_crypto.decrypt(multi_fernet_crypto.encrypt(data)) == data
+        # The single fernet with the first key should be able to decrypt the
+        # multi-fernet's encrypted data.
+        self.assertEqual(
+            current_crypto.decrypt(multi_fernet_crypto.encrypt(data)),
+            data
+        )
 
-    # Multi should be able decrypt anything encrypted with either key.
-    assert multi_fernet_crypto.decrypt(encrypted_data_current) == data
-    assert multi_fernet_crypto.decrypt(encrypted_data_old) == data
+        # Multi should be able decrypt anything encrypted with either key.
+        self.assertEqual(multi_fernet_crypto.decrypt(encrypted_data_current),
+                         data)
+        self.assertEqual(multi_fernet_crypto.decrypt(encrypted_data_old), data)
 
-    # Unencrypted data should be returned unchanged.
-    assert multi_fernet_crypto.decrypt(data) == data
+        # Unencrypted data should be returned unchanged.
+        self.assertEqual(multi_fernet_crypto.decrypt(data), data)
+
+    def test_memoized_crypto_factory(self):
+        full_calls = []
+
+        @MemoizedCryptoFactory
+        def mock_factory(user_id):
+            full_calls.append(user_id)
+            return u'crypto' + user_id
+
+        calls_to_make = [u'1', u'2', u'3', u'2', u'1']
+        expected_results = [u'crypto' + user_id for user_id in calls_to_make]
+        expected_full_calls = [u'1', u'2', u'3']
+
+        results = []
+        for user_id in calls_to_make:
+            results.append(mock_factory(user_id))
+
+        self.assertEqual(results, expected_results)
+        self.assertEqual(full_calls, expected_full_calls)

--- a/pgcontents/tests/test_encryption.py
+++ b/pgcontents/tests/test_encryption.py
@@ -9,7 +9,7 @@ from ..crypto import (
     derive_fallback_fernet_keys,
     FallbackCrypto,
     FernetEncryption,
-    MemoizedCryptoFactory,
+    memoize_single_arg,
     NoEncryption,
     single_password_crypto_factory,
 )
@@ -63,10 +63,10 @@ class TestEncryption(TestCase):
         # Unencrypted data should be returned unchanged.
         self.assertEqual(multi_fernet_crypto.decrypt(data), data)
 
-    def test_memoized_crypto_factory(self):
+    def test_memoize_single_arg(self):
         full_calls = []
 
-        @MemoizedCryptoFactory
+        @memoize_single_arg
         def mock_factory(user_id):
             full_calls.append(user_id)
             return u'crypto' + user_id

--- a/pgcontents/tests/test_synchronization.py
+++ b/pgcontents/tests/test_synchronization.py
@@ -199,6 +199,8 @@ class TestGenerateNotebooks(TestCase):
     def populate_users(self, user_ids):
         """
         Create a `PostgresContentsManager` and notebooks for each user.
+
+        Notebooks are returned in a list in order of their creation.
         """
         def encrypted_pgmanager(user_id):
             return PostgresContentsManager(
@@ -209,7 +211,9 @@ class TestGenerateNotebooks(TestCase):
             )
         managers = {user_id: encrypted_pgmanager(user_id)
                     for user_id in user_ids}
-        paths = {user_id: populate(managers[user_id]) for user_id in user_ids}
+        paths = [(user_id, path)
+                 for user_id in user_ids
+                 for path in populate(managers[user_id])]
         return (managers, paths)
 
     def test_generate_files(self):
@@ -221,20 +225,20 @@ class TestGenerateNotebooks(TestCase):
                     'test_generate_files2']
         (managers, paths) = self.populate_users(user_ids)
 
-        def get_file_dt(user_id, idx):
-            path = paths[user_id][idx]
+        def get_file_dt(idx):
+            (user_id, path) = paths[idx]
             return managers[user_id].get(path, content=False)['last_modified']
 
-        # Find a split datetime midway through each user's list of files
-        split_idx = len(paths[user_ids[0]]) // 2
-        split_dts = [get_file_dt(user_id, split_idx) for user_id in user_ids]
+        # Find three split datetimes
+        split_idxs = [i * (len(paths) // 4) for i in range(1, 4)]
+        split_dts = [get_file_dt(idx) for idx in split_idxs]
 
-        def check_call(kwargs, expect_files_by_user):
+        def check_call(kwargs, expect_files):
             """
             Call `generate_files`; check that all expected files are found,
-            with the correct content.
+            with the correct content, in the correct order.
             """
-            file_record = {user_id: [] for user_id in expect_files_by_user}
+            file_record = []
             for result in generate_files(self.engine, self.crypto_factory,
                                          **kwargs):
                 manager = managers[result['user_id']]
@@ -249,42 +253,20 @@ class TestGenerateNotebooks(TestCase):
                 # matches that returned by `generate_files`
                 self.assertEqual(nb, manager.get(result['path'])['content'])
 
-                file_record[result['user_id']].append(result['path'])
+                file_record.append((result['user_id'], result['path']))
 
-            # Make sure all files were found
-            for user_id in expect_files_by_user:
-                self.assertEqual(sorted(file_record[user_id]),
-                                 sorted(expect_files_by_user[user_id]))
+            # Make sure all files were found in the right order
+            self.assertEqual(file_record, expect_files)
 
         # Expect all files given no `min_dt`/`max_dt`
         check_call({}, paths)
 
-        # `min_dt` is in the middle of 1's files; we get the latter half of 1's
-        # and all of 2's
-        check_call({'min_dt': split_dts[1]},
-                   {
-                       user_ids[0]: [],
-                       user_ids[1]: paths[user_ids[1]][split_idx:],
-                       user_ids[2]: paths[user_ids[2]],
-                   })
+        check_call({'min_dt': split_dts[1]}, paths[split_idxs[1]:])
 
-        # `max_dt` is in the middle of 1's files; we get all of 0's and the
-        # beginning half of 1's
-        check_call({'max_dt': split_dts[1]},
-                   {
-                       user_ids[0]: paths[user_ids[0]],
-                       user_ids[1]: paths[user_ids[1]][:split_idx],
-                       user_ids[2]: [],
-                   })
+        check_call({'max_dt': split_dts[1]}, paths[:split_idxs[1]])
 
-        # `min_dt` is in the middle of 0's files cutting off 0's beginning half
-        # `max_dt` is in the middle of 2's files cutting off 2's latter half
         check_call({'min_dt': split_dts[0], 'max_dt': split_dts[2]},
-                   {
-                       user_ids[0]: paths[user_ids[0]][split_idx:],
-                       user_ids[1]: paths[user_ids[1]],
-                       user_ids[2]: paths[user_ids[2]][:split_idx],
-                   })
+                   paths[split_idxs[0]:split_idxs[2]])
 
     def test_generate_checkpoints(self):
         """
@@ -311,51 +293,41 @@ class TestGenerateNotebooks(TestCase):
             return manager.get(path)['content']
 
         # Each of the next three steps creates a checkpoint for each notebook
-        # and stores the notebook content in a dict, keyed by the user id,
+        # and stores the notebook content in a list, together with the user id,
         # the path, and the datetime of the new checkpoint.
 
         # Begin by making a checkpoint for the original notebook content.
-        beginning_content = {}
-        for user_id in user_ids:
-            for path in paths[user_id]:
-                content = managers[user_id].get(path)['content']
-                dt = managers[user_id].create_checkpoint(path)['last_modified']
-                beginning_content[user_id, path, dt] = content
+        beginning_checkpoints = []
+        for user_id, path in paths:
+            content = managers[user_id].get(path)['content']
+            dt = managers[user_id].create_checkpoint(path)['last_modified']
+            beginning_checkpoints.append((user_id, path, dt, content))
 
         # Update each notebook and make a new checkpoint.
-        middle_content = {}
+        middle_checkpoints = []
         middle_min_dt = None
-        for user_id in user_ids:
-            for path in paths[user_id]:
-                content = update_content(user_id, path, '1st addition')
-                dt = managers[user_id].create_checkpoint(path)['last_modified']
-                middle_content[user_id, path, dt] = content
-                if middle_min_dt is None:
-                    middle_min_dt = dt
+        for user_id, path in paths:
+            content = update_content(user_id, path, '1st addition')
+            dt = managers[user_id].create_checkpoint(path)['last_modified']
+            middle_checkpoints.append((user_id, path, dt, content))
+            if middle_min_dt is None:
+                middle_min_dt = dt
 
         # Update each notebook again and make another checkpoint.
-        end_content = {}
+        end_checkpoints = []
         end_min_dt = None
-        for user_id in user_ids:
-            for path in paths[user_id]:
-                content = update_content(user_id, path, '2nd addition')
-                dt = managers[user_id].create_checkpoint(path)['last_modified']
-                end_content[user_id, path, dt] = content
-                if end_min_dt is None:
-                    end_min_dt = dt
+        for user_id, path in paths:
+            content = update_content(user_id, path, '2nd addition')
+            dt = managers[user_id].create_checkpoint(path)['last_modified']
+            end_checkpoints.append((user_id, path, dt, content))
+            if end_min_dt is None:
+                end_min_dt = dt
 
-        def merge_dicts(*args):
-            result = {}
-            for d in args:
-                result.update(d)
-            return result
-
-        def check_call(kwargs, expect_checkpoints_content):
+        def check_call(kwargs, expect_checkpoints):
             """
             Call `generate_checkpoints`; check that all expected checkpoints
-            are found, with the correct content.
+            are found, with the correct content, in the correct order.
             """
-            expect_checkpoints = expect_checkpoints_content.keys()
             checkpoint_record = []
             for result in generate_checkpoints(self.engine,
                                                self.crypto_factory, **kwargs):
@@ -367,29 +339,24 @@ class TestGenerateNotebooks(TestCase):
                 nb = result['content']
                 manager.mark_trusted_cells(nb, result['path'])
 
-                # Check that the checkpoint content matches what's expected
-                key = (result['user_id'], result['path'],
-                       result['last_modified'])
-                self.assertEqual(nb, expect_checkpoints_content[key])
+                checkpoint_record.append((result['user_id'], result['path'],
+                                          result['last_modified'], nb))
 
-                checkpoint_record.append(key)
-
-            # Make sure all checkpoints were found
-            self.assertEqual(sorted(checkpoint_record),
-                             sorted(expect_checkpoints))
+            # Make sure all checkpoints were found in the right order
+            self.assertEqual(checkpoint_record, expect_checkpoints)
 
         # No `min_dt`/`max_dt`
-        check_call({}, merge_dicts(beginning_content,
-                                   middle_content, end_content))
+        check_call({}, sum([beginning_checkpoints, middle_checkpoints,
+                            end_checkpoints], []))
 
-        # `min_dt` cuts off `beginning_content` checkpoints
+        # `min_dt` cuts off `beginning_checkpoints` checkpoints
         check_call({'min_dt': middle_min_dt},
-                   merge_dicts(middle_content, end_content))
+                   sum([middle_checkpoints, end_checkpoints], []))
 
-        # `max_dt` cuts off `end_content` checkpoints
+        # `max_dt` cuts off `end_checkpoints` checkpoints
         check_call({'max_dt': end_min_dt},
-                   merge_dicts(beginning_content, middle_content))
+                   sum([beginning_checkpoints, middle_checkpoints], []))
 
-        # `min_dt` and `max_dt` together isolate `middle_content`
+        # `min_dt` and `max_dt` together isolate `middle_checkpoints`
         check_call({'min_dt': middle_min_dt, 'max_dt': end_min_dt},
-                   middle_content)
+                   middle_checkpoints)

--- a/pgcontents/tests/test_synchronization.py
+++ b/pgcontents/tests/test_synchronization.py
@@ -230,7 +230,8 @@ class TestGenerateNotebooks(TestCase):
             return managers[user_id].get(path, content=False)['last_modified']
 
         # Find three split datetimes
-        split_idxs = [i * (len(paths) // 4) for i in range(1, 4)]
+        n = 3
+        split_idxs = [i * (len(paths) // (n + 1)) for i in range(1, n + 1)]
         split_dts = [get_file_dt(idx) for idx in split_idxs]
 
         def check_call(kwargs, expect_files):
@@ -323,6 +324,9 @@ class TestGenerateNotebooks(TestCase):
             if end_min_dt is None:
                 end_min_dt = dt
 
+        def concat_all(lists):
+            return sum(lists, [])
+
         def check_call(kwargs, expect_checkpoints):
             """
             Call `generate_checkpoints`; check that all expected checkpoints
@@ -346,16 +350,16 @@ class TestGenerateNotebooks(TestCase):
             self.assertEqual(checkpoint_record, expect_checkpoints)
 
         # No `min_dt`/`max_dt`
-        check_call({}, sum([beginning_checkpoints, middle_checkpoints,
-                            end_checkpoints], []))
+        check_call({}, concat_all([beginning_checkpoints, middle_checkpoints,
+                                   end_checkpoints]))
 
         # `min_dt` cuts off `beginning_checkpoints` checkpoints
         check_call({'min_dt': middle_min_dt},
-                   sum([middle_checkpoints, end_checkpoints], []))
+                   concat_all([middle_checkpoints, end_checkpoints]))
 
         # `max_dt` cuts off `end_checkpoints` checkpoints
         check_call({'max_dt': end_min_dt},
-                   sum([beginning_checkpoints, middle_checkpoints], []))
+                   concat_all([beginning_checkpoints, middle_checkpoints]))
 
         # `min_dt` and `max_dt` together isolate `middle_checkpoints`
         check_call({'min_dt': middle_min_dt, 'max_dt': end_min_dt},


### PR DESCRIPTION
Output of `generate_files` and `generate_checkpoints` is now ordered by datetime (last modified dt). This helps a lot when working with large numbers of outputted notebooks.

Since the notebooks are no longer ordered by user_id as they were before, we rely on a memoized crypto factory approach to minimize crypto factory calls. This memoization is available via a new decorator class `MemoizedCryptoFactory`, which is integrated into `single_password_crypto_factory`. Note that the burden now falls on the user to make use of this decorator on custom crypto factories.