### PR TITLE
BUG: Fix `generate_files` raising CorruptedFile on non-notebook files

### DIFF
--- a/pgcontents/query.py
+++ b/pgcontents/query.py
@@ -31,6 +31,7 @@ from .db_utils import (
     to_dict_with_content,
 )
 from .error import (
+    CorruptedFile,
     DirectoryNotEmpty,
     FileExists,
     DirectoryExists,
@@ -549,7 +550,8 @@ def save_file(db, user_id, path, content, encrypt_func, max_size_bytes):
     return res
 
 
-def generate_files(engine, crypto_factory, min_dt=None, max_dt=None):
+def generate_files(engine, crypto_factory, min_dt=None, max_dt=None,
+                   logger=None):
     """
     Create a generator of decrypted files.
 
@@ -572,9 +574,10 @@ def generate_files(engine, crypto_factory, min_dt=None, max_dt=None):
         Minimum last modified datetime at which a file will be included.
     max_dt : datetime.datetime, optional
         Last modified datetime at and after which a file will be excluded.
+    logger : Logger, optional
     """
     return _generate_notebooks(files, files.c.created_at,
-                               engine, crypto_factory, min_dt, max_dt)
+                               engine, crypto_factory, min_dt, max_dt, logger)
 
 
 # =======================================
@@ -730,7 +733,8 @@ def purge_remote_checkpoints(db, user_id):
     )
 
 
-def generate_checkpoints(engine, crypto_factory, min_dt=None, max_dt=None):
+def generate_checkpoints(engine, crypto_factory, min_dt=None, max_dt=None,
+                         logger=None):
     """
     Create a generator of decrypted remote checkpoints.
 
@@ -753,17 +757,18 @@ def generate_checkpoints(engine, crypto_factory, min_dt=None, max_dt=None):
         Minimum last modified datetime at which a file will be included.
     max_dt : datetime.datetime, optional
         Last modified datetime at and after which a file will be excluded.
+    logger : Logger, optional
     """
     return _generate_notebooks(remote_checkpoints,
                                remote_checkpoints.c.last_modified,
-                               engine, crypto_factory, min_dt, max_dt)
+                               engine, crypto_factory, min_dt, max_dt, logger)
 
 
 # ====================
 # Files or Checkpoints
 # ====================
 def _generate_notebooks(table, timestamp_column,
-                        engine, crypto_factory, min_dt, max_dt):
+                        engine, crypto_factory, min_dt, max_dt, logger):
     """
     See docstrings for `generate_files` and `generate_checkpoints`.
 
@@ -779,10 +784,11 @@ def _generate_notebooks(table, timestamp_column,
         A function from user_id to an object providing the interface required
         by PostgresContentsManager.crypto.  Results of this will be used for
         decryption of the selected notebooks.
-    min_dt : datetime.datetime, optional
+    min_dt : datetime.datetime
         Minimum last modified datetime at which a file will be included.
-    max_dt : datetime.datetime, optional
+    max_dt : datetime.datetime
         Last modified datetime at and after which a file will be excluded.
+    logger : Logger
     """
     where_conds = []
     if min_dt is not None:
@@ -798,26 +804,33 @@ def _generate_notebooks(table, timestamp_column,
 
     # Decrypt each notebook and yield the result.
     for nb_row in result:
-        # The decrypt function depends on the user
-        user_id = nb_row['user_id']
-        decrypt_func = crypto_factory(user_id).decrypt
+        try:
+            # The decrypt function depends on the user
+            user_id = nb_row['user_id']
+            decrypt_func = crypto_factory(user_id).decrypt
 
-        nb_dict = to_dict_with_content(table.c, nb_row, decrypt_func)
-        if table is files:
-            # Correct for files schema differing somewhat from checkpoints.
-            nb_dict['path'] = nb_dict['parent_name'] + nb_dict['name']
-            nb_dict['last_modified'] = nb_dict['created_at']
+            nb_dict = to_dict_with_content(table.c, nb_row, decrypt_func)
+            if table is files:
+                # Correct for files schema differing somewhat from checkpoints.
+                nb_dict['path'] = nb_dict['parent_name'] + nb_dict['name']
+                nb_dict['last_modified'] = nb_dict['created_at']
 
-        # For 'content', we use `reads_base64` directly. If the db content
-        # format is changed from base64, the decoding should be changed
-        # here as well.
-        yield {
-            'id': nb_dict['id'],
-            'user_id': user_id,
-            'path': to_api_path(nb_dict['path']),
-            'last_modified': nb_dict['last_modified'],
-            'content': reads_base64(nb_dict['content']),
-        }
+            # For 'content', we use `reads_base64` directly. If the db content
+            # format is changed from base64, the decoding should be changed
+            # here as well.
+            yield {
+                'id': nb_dict['id'],
+                'user_id': user_id,
+                'path': to_api_path(nb_dict['path']),
+                'last_modified': nb_dict['last_modified'],
+                'content': reads_base64(nb_dict['content']),
+            }
+        except CorruptedFile:
+            logger.warning(
+                'Corrupted file with id {} in table {}.',
+                nb_row['id'],
+                table.name,
+            )
 
 
 ##########################

--- a/pgcontents/query.py
+++ b/pgcontents/query.py
@@ -795,6 +795,9 @@ def _generate_notebooks(table, timestamp_column,
         where_conds.append(timestamp_column >= min_dt)
     if max_dt is not None:
         where_conds.append(timestamp_column < max_dt)
+    if table is files:
+        # Only select files that are notebooks
+        where_conds.append(files.c.name.like(u'%.ipynb'))
 
     # Query for notebooks satisfying the conditions.
     query = select([table]).order_by(timestamp_column)
@@ -826,11 +829,12 @@ def _generate_notebooks(table, timestamp_column,
                 'content': reads_base64(nb_dict['content']),
             }
         except CorruptedFile:
-            logger.warning(
-                'Corrupted file with id {} in table {}.',
-                nb_row['id'],
-                table.name,
-            )
+            if logger is not None:
+                logger.warning(
+                    'Corrupted file with id {} in table {}.',
+                    nb_row['id'],
+                    table.name,
+                )
 
 
 ##########################

--- a/pgcontents/query.py
+++ b/pgcontents/query.py
@@ -831,9 +831,8 @@ def _generate_notebooks(table, timestamp_column,
         except CorruptedFile:
             if logger is not None:
                 logger.warning(
-                    'Corrupted file with id {} in table {}.',
-                    nb_row['id'],
-                    table.name,
+                    'Corrupted file with id %d in table %s.'
+                    % (nb_row['id'], table.name)
                 )
 
 

--- a/pgcontents/tests/test_synchronization.py
+++ b/pgcontents/tests/test_synchronization.py
@@ -214,6 +214,13 @@ class TestGenerateNotebooks(TestCase):
         paths = [(user_id, path)
                  for user_id in user_ids
                  for path in populate(managers[user_id])]
+
+        # Create a text file for each user as well, which should be ignored by
+        # the notebook generators
+        model = {'content': 'text file contents', 'format': 'text'}
+        for manager in managers.values():
+            manager.new(model, path='text file.txt')
+
         return (managers, paths)
 
     def test_generate_files(self):

--- a/pgcontents/tests/test_synchronization.py
+++ b/pgcontents/tests/test_synchronization.py
@@ -30,6 +30,11 @@ from ..utils.sync import (
     unencrypt_all_users,
 )
 
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
 
 class TestReEncryption(TestCase):
 
@@ -223,6 +228,22 @@ class TestGenerateNotebooks(TestCase):
 
         return (managers, paths)
 
+    def save_bad_notebook(self, manager):
+        """
+        Save a notebook with non-notebook content. Trying to parse it should
+        cause `CorruptedFile` to be raised.
+
+        Returns the file id of the saved notebook.
+        """
+        model = {
+            'type': 'file',
+            'content': 'bad notebook contents',
+            'format': 'text',
+        }
+        path = 'bad notebook.ipynb'
+        manager.new(model, path=path)
+        return manager.get_file_id(path)
+
     def test_generate_files(self):
         """
         Create files for three users; try fetching them using `generate_files`.
@@ -231,6 +252,10 @@ class TestGenerateNotebooks(TestCase):
                     'test_generate_files1',
                     'test_generate_files2']
         (managers, paths) = self.populate_users(user_ids)
+
+        # Since the bad notebook is saved last, it will be hit only when no
+        # max_dt is specified.
+        bad_notebook_id = self.save_bad_notebook(managers[user_ids[0]])
 
         def get_file_dt(idx):
             (user_id, path) = paths[idx]
@@ -241,40 +266,69 @@ class TestGenerateNotebooks(TestCase):
         split_idxs = [i * (len(paths) // (n + 1)) for i in range(1, n + 1)]
         split_dts = [get_file_dt(idx) for idx in split_idxs]
 
-        def check_call(kwargs, expect_files):
+        def check_call(kwargs, expect_files, expect_warning=False):
             """
             Call `generate_files`; check that all expected files are found,
             with the correct content, in the correct order.
             """
             file_record = []
-            for result in generate_files(self.engine, self.crypto_factory,
-                                         **kwargs):
-                manager = managers[result['user_id']]
+            logger = Logger('Generate Files Testing')
+            with mock.patch.object(logger, 'warning') as mock_warn:
+                for result in generate_files(self.engine, self.crypto_factory,
+                                             logger=logger, **kwargs):
+                    manager = managers[result['user_id']]
 
-                # This recreates functionality from
-                # `manager._notebook_model_from_db` to match with the model
-                # returned by `manager.get`.
-                nb = result['content']
-                manager.mark_trusted_cells(nb, result['path'])
+                    # This recreates functionality from
+                    # `manager._notebook_model_from_db` to match with the model
+                    # returned by `manager.get`.
+                    nb = result['content']
+                    manager.mark_trusted_cells(nb, result['path'])
 
-                # Check that the content returned by the pgcontents manager
-                # matches that returned by `generate_files`
-                self.assertEqual(nb, manager.get(result['path'])['content'])
+                    # Check that the content returned by the pgcontents manager
+                    # matches that returned by `generate_files`
+                    self.assertEqual(
+                        nb,
+                        manager.get(result['path'])['content']
+                    )
 
-                file_record.append((result['user_id'], result['path']))
+                    file_record.append((result['user_id'], result['path']))
+
+                if expect_warning:
+                    mock_warn.assert_called_with(
+                        'Corrupted file with id %d in table files.'
+                        % bad_notebook_id
+                    )
+                    mock_warn.reset_mock()
+                else:
+                    mock_warn.assert_not_called()
 
             # Make sure all files were found in the right order
             self.assertEqual(file_record, expect_files)
 
         # Expect all files given no `min_dt`/`max_dt`
-        check_call({}, paths)
+        check_call(
+            {},
+            paths,
+            expect_warning=True,
+        )
 
-        check_call({'min_dt': split_dts[1]}, paths[split_idxs[1]:])
+        check_call(
+            {'min_dt': split_dts[1]},
+            paths[split_idxs[1]:],
+            expect_warning=True,
+        )
 
-        check_call({'max_dt': split_dts[1]}, paths[:split_idxs[1]])
+        check_call(
+            {'max_dt': split_dts[1]},
+            paths[:split_idxs[1]],
+            expect_warning=False,
+        )
 
-        check_call({'min_dt': split_dts[0], 'max_dt': split_dts[2]},
-                   paths[split_idxs[0]:split_idxs[2]])
+        check_call(
+            {'min_dt': split_dts[0], 'max_dt': split_dts[2]},
+            paths[split_idxs[0]:split_idxs[2]],
+            expect_warning=False,
+        )
 
     def test_generate_checkpoints(self):
         """

--- a/pgcontents/tests/test_synchronization.py
+++ b/pgcontents/tests/test_synchronization.py
@@ -294,7 +294,7 @@ class TestGenerateNotebooks(TestCase):
                     file_record.append((result['user_id'], result['path']))
 
                 if expect_warning:
-                    mock_warn.assert_called_with(
+                    mock_warn.assert_called_once_with(
                         'Corrupted file with id %d in table files.'
                         % bad_notebook_id
                     )

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,3 +7,4 @@ pyflakes==0.9.2
 pep8==1.6.2
 mccabe==0.3.1
 flake8==2.2.5
+mock==2.0.0


### PR DESCRIPTION
Now, when selecting from the `files` table in `_generate_notebooks`, we add a `WHERE name LIKE '%.ipynb'` to get only notebooks. Also, during the notebook decryption and decoding, we catch and log CorruptedFile, instead of the generator blowing up when it encounters a corrupted or incompatible file.