### PR TITLE
Added tests for newer versions of ipython and python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,20 @@
 language: python
 sudo: false
-python:
-  - "2.7"
-  - "3.4"
-env:
-  - IPYTHON=3
-  - IPYTHON=4
+
+matrix:
+  include:
+    - python: 2.7
+      env: IPYTHON=3
+    - python: 2.7
+      env: IPYTHON=4
+
+    - python: 3.4
+      env: IPYTHON=3
+    - python: 3.4
+      env: IPYTHON=4
+
+    - python: 3.6
+      env: IPYTHON=6
 
 addons:
   postgresql: "9.3"
@@ -16,6 +25,7 @@ install:
 script:
   - if [[ $TRAVIS_PYTHON_VERSION = '2.7' ]]; then tox -e py27-ipython$IPYTHON,flake8; fi
   - if [[ $TRAVIS_PYTHON_VERSION = '3.4' ]]; then tox -e py34-ipython$IPYTHON,flake8; fi
+  - if [[ $TRAVIS_PYTHON_VERSION = '3.6' ]]; then tox -e py36-ipython$IPYTHON; fi
 
 branches:
   only:

--- a/pgcontents/pgmanager.py
+++ b/pgcontents/pgmanager.py
@@ -77,7 +77,7 @@ class PostgresContentsManager(PostgresManagerMixin, ContentsManager):
             klass = PostgresContentsManager
             kw = super(klass, self)._checkpoints_kwargs_default()
         except AttributeError:
-            kw = {}
+            kw = {'parent': self, 'log': self.log}
         kw.update({
             'create_user_on_startup': self.create_user_on_startup,
             'crypto': self.crypto,

--- a/pgcontents/pgmanager.py
+++ b/pgcontents/pgmanager.py
@@ -73,7 +73,11 @@ class PostgresContentsManager(PostgresManagerMixin, ContentsManager):
         return PostgresCheckpoints
 
     def _checkpoints_kwargs_default(self):
-        kw = super(PostgresContentsManager, self)._checkpoints_kwargs_default()
+        #_checkpoints_kwargs_default
+        try:
+            kw = super(PostgresContentsManager, self)._checkpoints_kwargs_default()
+        except AttributeError:
+            kw = {}
         kw.update({
             'create_user_on_startup': self.create_user_on_startup,
             'crypto': self.crypto,

--- a/pgcontents/pgmanager.py
+++ b/pgcontents/pgmanager.py
@@ -73,9 +73,9 @@ class PostgresContentsManager(PostgresManagerMixin, ContentsManager):
         return PostgresCheckpoints
 
     def _checkpoints_kwargs_default(self):
-        #_checkpoints_kwargs_default
         try:
-            kw = super(PostgresContentsManager, self)._checkpoints_kwargs_default()
+            kw = (super(PostgresContentsManager, self).
+                _checkpoints_kwargs_default())
         except AttributeError:
             kw = {}
         kw.update({

--- a/pgcontents/pgmanager.py
+++ b/pgcontents/pgmanager.py
@@ -74,8 +74,8 @@ class PostgresContentsManager(PostgresManagerMixin, ContentsManager):
 
     def _checkpoints_kwargs_default(self):
         try:
-            kw = (super(PostgresContentsManager, self).
-                _checkpoints_kwargs_default())
+            klass = PostgresContentsManager
+            kw = super(klass, self)._checkpoints_kwargs_default()
         except AttributeError:
             kw = {}
         kw.update({

--- a/pgcontents/tests/test_pgcontents_api.py
+++ b/pgcontents/tests/test_pgcontents_api.py
@@ -51,7 +51,7 @@ from .utils import (
 )
 from ..utils.ipycompat import (
     APITest, Config, FileContentsManager, GenericFileCheckpoints, to_os_path,
-)
+    IPY3)
 from ..utils.sync import walk, walk_dirs
 
 
@@ -170,9 +170,30 @@ class _APITestBase(APITest):
 
         # Old behaviour
         # from notebook.tests.launchnotebook import assert_http_error
-        # with assert_http_error(400):
-        #    self.api.delete(u'å b')
-        pass
+
+        if isinstance(self.notebook.contents_manager, PostgresContentsManager):
+            _test_delete_non_empty_dir_fail(self)
+        else:
+            _test_delete_non_empty_dir_pass(self)
+
+
+def _test_delete_non_empty_dir_fail(self):
+    if IPY3:
+        return
+    from notebook.tests.launchnotebook import assert_http_error
+    with assert_http_error(400):
+        self.api.delete(u'å b')
+
+
+def _test_delete_non_empty_dir_pass(self):
+    if IPY3:
+        return
+    from notebook.tests.launchnotebook import assert_http_error
+    # Test that non empty directory can be deleted
+    self.api.delete(u'å b')
+    # Check if directory has actually been deleted
+    with assert_http_error(404):
+        self.api.list(u'å b')
 
 
 def postgres_contents_config():

--- a/pgcontents/tests/test_pgcontents_api.py
+++ b/pgcontents/tests/test_pgcontents_api.py
@@ -163,6 +163,17 @@ class _APITestBase(APITest):
             )
         )
 
+    # skip this test since it is satisfyable across all supported notebook versions
+    def test_delete_non_empty_dir(self):
+        # ContentsManager has different behaviour in notebook 5.5+
+        # https://github.com/jupyter/notebook/pull/3108
+
+        # Old behaviour
+        # from notebook.tests.launchnotebook import assert_http_error
+        # with assert_http_error(400):
+        #    self.api.delete(u'å b')
+        pass
+
 
 def postgres_contents_config():
     """
@@ -290,14 +301,6 @@ class PostgresContentsAPITest(_APITestBase):
         self.assertIsInstance(self.pg_manager.crypto, NoEncryption)
         self.assertIsInstance(self.pg_manager.checkpoints.crypto, NoEncryption)
 
-    # Changes behaviour in 5.5
-    def test_delete_non_empty_dir(self):
-        # Test that non empty directory can be deleted
-        pass
-        # from notebook.tests.launchnotebook import assert_http_error
-        # with assert_http_error(400):
-        #    self.api.delete(u'å b')
-
 
 class EncryptedPostgresContentsAPITest(PostgresContentsAPITest):
     config = postgres_contents_config()
@@ -374,9 +377,6 @@ class PostgresCheckpointsAPITest(_APITestBase):
     def test_checkpoints_separate_root(self):
         pass
 
-    def test_delete_non_empty_dir(self):
-        self.api.delete(u'å b')
-
 
 class EncryptedPostgresCheckpointsAPITest(PostgresCheckpointsAPITest):
     config = postgres_checkpoints_config()
@@ -384,8 +384,6 @@ class EncryptedPostgresCheckpointsAPITest(PostgresCheckpointsAPITest):
 
     def test_crypto_types(self):
         self.assertIsInstance(self.checkpoints.crypto, FernetEncryption)
-
-    test_delete_non_empty_dir = _APITestBase.test_delete_non_empty_dir
 
 
 class HybridContentsPGRootAPITest(PostgresContentsAPITest):
@@ -497,10 +495,6 @@ class EncryptedHybridContentsAPITest(HybridContentsPGRootAPITest):
             self.pg_manager.checkpoints.crypto,
             FernetEncryption,
         )
-
-    # This is weeird in any case
-    def test_delete_non_empty_dir(self):
-        pass
 
 
 # This needs to be removed or else we'll run the main IPython tests as well.

--- a/pgcontents/tests/test_pgcontents_api.py
+++ b/pgcontents/tests/test_pgcontents_api.py
@@ -453,12 +453,12 @@ class HybridContentsPGRootAPITest(PostgresContentsAPITest):
         'isfile',
         'isdir',
     ]
-    l = locals()
+    locs = locals()
     for method_name in __methods_to_multiplex:
-        l[method_name] = __api_path_dispatch(method_name)
+        locs[method_name] = __api_path_dispatch(method_name)
     del __methods_to_multiplex
     del __api_path_dispatch
-    del l
+    del locs
 
     # Override to not delete the root of the file subsystem.
     def test_delete_dirs(self):

--- a/pgcontents/tests/test_pgcontents_api.py
+++ b/pgcontents/tests/test_pgcontents_api.py
@@ -21,7 +21,6 @@ from base64 import (
     b64encode,
 )
 from dateutil.parser import parse
-from notebook.tests.launchnotebook import assert_http_error
 from six import iteritems
 
 from IPython.utils.tempdir import TemporaryDirectory
@@ -291,11 +290,13 @@ class PostgresContentsAPITest(_APITestBase):
         self.assertIsInstance(self.pg_manager.crypto, NoEncryption)
         self.assertIsInstance(self.pg_manager.checkpoints.crypto, NoEncryption)
 
-    # Change behaviour in 5.5
+    # Changes behaviour in 5.5
     def test_delete_non_empty_dir(self):
         # Test that non empty directory can be deleted
-        with assert_http_error(400):
-            self.api.delete(u'å b')
+        pass
+        # from notebook.tests.launchnotebook import assert_http_error
+        # with assert_http_error(400):
+        #    self.api.delete(u'å b')
 
 
 class EncryptedPostgresContentsAPITest(PostgresContentsAPITest):

--- a/pgcontents/tests/test_pgcontents_api.py
+++ b/pgcontents/tests/test_pgcontents_api.py
@@ -163,7 +163,7 @@ class _APITestBase(APITest):
             )
         )
 
-    # skip this test since it is satisfyable across all supported notebook versions
+    # skip test as it is not satisfyable across supported notebook versions
     def test_delete_non_empty_dir(self):
         # ContentsManager has different behaviour in notebook 5.5+
         # https://github.com/jupyter/notebook/pull/3108

--- a/pgcontents/tests/test_pgcontents_api.py
+++ b/pgcontents/tests/test_pgcontents_api.py
@@ -21,6 +21,7 @@ from base64 import (
     b64encode,
 )
 from dateutil.parser import parse
+from notebook.tests.launchnotebook import assert_http_error
 from six import iteritems
 
 from IPython.utils.tempdir import TemporaryDirectory
@@ -290,6 +291,12 @@ class PostgresContentsAPITest(_APITestBase):
         self.assertIsInstance(self.pg_manager.crypto, NoEncryption)
         self.assertIsInstance(self.pg_manager.checkpoints.crypto, NoEncryption)
 
+    # Change behaviour in 5.5
+    def test_delete_non_empty_dir(self):
+        # Test that non empty directory can be deleted
+        with assert_http_error(400):
+            self.api.delete(u'å b')
+
 
 class EncryptedPostgresContentsAPITest(PostgresContentsAPITest):
     config = postgres_contents_config()
@@ -366,6 +373,9 @@ class PostgresCheckpointsAPITest(_APITestBase):
     def test_checkpoints_separate_root(self):
         pass
 
+    def test_delete_non_empty_dir(self):
+        self.api.delete(u'å b')
+
 
 class EncryptedPostgresCheckpointsAPITest(PostgresCheckpointsAPITest):
     config = postgres_checkpoints_config()
@@ -373,6 +383,8 @@ class EncryptedPostgresCheckpointsAPITest(PostgresCheckpointsAPITest):
 
     def test_crypto_types(self):
         self.assertIsInstance(self.checkpoints.crypto, FernetEncryption)
+
+    test_delete_non_empty_dir = _APITestBase.test_delete_non_empty_dir
 
 
 class HybridContentsPGRootAPITest(PostgresContentsAPITest):
@@ -484,6 +496,10 @@ class EncryptedHybridContentsAPITest(HybridContentsPGRootAPITest):
             self.pg_manager.checkpoints.crypto,
             FernetEncryption,
         )
+
+    # This is weeird in any case
+    def test_delete_non_empty_dir(self):
+        pass
 
 
 # This needs to be removed or else we'll run the main IPython tests as well.

--- a/pgcontents/utils/ipycompat.py
+++ b/pgcontents/utils/ipycompat.py
@@ -3,7 +3,7 @@ Utilities for managing IPython 3/4 compat.
 """
 import IPython
 
-SUPPORTED_VERSIONS = {3, 4, 5}
+SUPPORTED_VERSIONS = {3, 4, 5, 6}
 IPY_MAJOR = IPython.version_info[0]
 if IPY_MAJOR not in SUPPORTED_VERSIONS:
     raise ImportError("IPython version %d is not supported." % IPY_MAJOR)
@@ -47,8 +47,8 @@ if IPY3:
     )
 else:
     import notebook
-    if notebook.version_info[0] >= 5:
-        raise ImportError("Notebook versions 5 and up are not supported.")
+    if notebook.version_info[0] >= 6:
+        raise ImportError("Notebook versions 6 and up are not supported.")
 
     from traitlets.config import Config
     from notebook.services.contents.checkpoints import (

--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,8 @@ def main():
         install_requires=reqs,
         extras_require={
             'test': test_reqs,
-            'ipy3': ['ipython[test,notebook]<4.0'],
-            'ipy4': ['ipython<6.0', 'notebook[test]>=4.0,<5.0'],
+            'ipy3': ['ipython[test,notebook]<4.0', 'tornado<5.0'],
+            'ipy4': ['ipython<6.0', 'notebook[test]>=4.0,<5.0', 'tornado<5.0'],
             'ipy6': ['ipython>6.0', 'notebook[test]>=5.0']
         },
         scripts=[

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ def main():
             'test': test_reqs,
             'ipy3': ['ipython[test,notebook]<4.0'],
             'ipy4': ['ipython<6.0', 'notebook[test]>=4.0,<5.0'],
+            'ipy6': ['ipython>6.0', 'notebook[test]>=5.0']
         },
         scripts=[
             'bin/pgcontents',

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ def main():
             'test': test_reqs,
             'ipy3': ['ipython[test,notebook]<4.0', 'tornado<5.0'],
             'ipy4': ['ipython<6.0', 'notebook[test]>=4.0,<5.0', 'tornado<5.0'],
-            'ipy6': ['ipython>6.0', 'notebook[test]>=5.0']
+            'ipy6': ['ipython>=6.0', 'notebook[test]>=5.0']
         },
         scripts=[
             'bin/pgcontents',

--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,8 @@ deps =
 
 commands =
     py{27,34}-ipython{3,4}: -createdb pgcontents_testing
-    py36-ipython6: -createdb pgcontents_testing
     py{27,34}-ipython{3,4}: nosetests pgcontents/tests
+    py36-ipython6: -createdb pgcontents_testing
     py36-ipython6: nosetests pgcontents/tests
     flake8: flake8 pgcontents
     notest: python -c 'from pgcontents.utils.ipycompat import *'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{27,34}-ipython{3,4},flake8
+envlist=py{27,34}-ipython{3,4},py36-ipython6,flake8
 skip_missing_interpreters=True
 
 [testenv]
@@ -9,11 +9,14 @@ whitelist_externals =
 deps =
     py{27,34}-ipython3: .[test,ipy3]
     py{27,34}-ipython4: .[test,ipy4]
+    py36-ipython6: .[test,ipy6]
     flake8: flake8
     notest: .[ipy4]
 
 commands =
     py{27,34}-ipython{3,4}: -createdb pgcontents_testing
+    py36-ipython6: -createdb pgcontents_testing
     py{27,34}-ipython{3,4}: nosetests pgcontents/tests
+    py36-ipython6: nosetests pgcontents/tests
     flake8: flake8 pgcontents
     notest: python -c 'from pgcontents.utils.ipycompat import *'


### PR DESCRIPTION
There is a small change in behavior for one of the contents manager pieces in notebook 5.5.  This adds some support for newer ipython versions and adds some more tests.  Resolves #28