### PR TITLE
TEST: Another attempt at preventing tests from moving files to the OS trash can

### DIFF
--- a/pgcontents/tests/test_pgcontents_api.py
+++ b/pgcontents/tests/test_pgcontents_api.py
@@ -62,6 +62,10 @@ class _APITestBase(APITest):
     """
     APITest that also runs a test for our implementation of `walk`.
     """
+
+    config = Config()
+    config.FileContentsManager.delete_to_trash = False
+
     def test_walk(self):
         """
         Test ContentsManager.walk.
@@ -377,6 +381,7 @@ def postgres_checkpoints_config():
     """
     config = Config()
     config.NotebookApp.contents_manager_class = FileContentsManager
+    config.FileContentsManager.delete_to_trash = False
     config.ContentsManager.checkpoints_class = PostgresCheckpoints
     config.PostgresCheckpoints.user_id = 'test'
     config.PostgresCheckpoints.db_url = TEST_DB_URL


### PR DESCRIPTION
It appears I missed some spots in my first attempt in https://github.com/quantopian/pgcontents/pull/47.  I was able to simulate by raising an error on this line: https://github.com/quantopian/notebook/blob/master/notebook/services/contents/filemanager.py#L531 when running locally, so I'm pretty sure I've identified all the places where we need to set this option to False.