### PR TITLE
Only use Notebook version less than 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,11 @@ env:
   - FLAKE8=true NB_VERSION=5
   - NOTEST=true NB_VERSION=5
 
+services:
+  - postgresql
+
 addons:
-  postgresql: "9.3"
+  postgresql: "9.5"
 
 install:
   - pip install tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ cryptography>=1.4
 psycopg2>=2.6.1
 requests>=2.7.0
 six>=1.9.0
-notebook[test]>=4.0
+notebook[test]>=4.0,<6


### PR DESCRIPTION
[Jupyter Notebook version 6](https://github.com/jupyter/notebook/releases/tag/6.0.0) just got released, but until we've added it to the test matrix and removed [this check](https://github.com/quantopian/pgcontents/blob/master/pgcontents/utils/ipycompat.py#L5-L6), for now we will make the requirement for notebook be <6.