### PR TITLE
Dispose of Engines in Tests

### DIFF
--- a/pgcontents/alembic/env.py
+++ b/pgcontents/alembic/env.py
@@ -74,6 +74,7 @@ def run_migrations_online():
             context.run_migrations()
     finally:
         connection.close()
+        engine.dispose()
 
 
 if context.is_offline_mode():

--- a/pgcontents/tests/test_hybrid_manager.py
+++ b/pgcontents/tests/test_hybrid_manager.py
@@ -83,6 +83,9 @@ class PostgresTestCase(PostgresContentsManagerTestCase):
             managers={'': self._pgmanager}
         )
 
+        self.addCleanup(self._pgmanager.engine.dispose)
+        self.addCleanup(self._pgmanager.checkpoints.engine.dispose)
+
     # HybridContentsManager is not expected to dispatch calls to get_file_id
     # because PostgresContentsManager is the only contents manager that
     # implements it.

--- a/pgcontents/tests/test_pgcontents_api.py
+++ b/pgcontents/tests/test_pgcontents_api.py
@@ -271,6 +271,10 @@ class PostgresContentsAPITest(_APITestBase):
         self.pg_manager.ensure_root_directory()
         super(PostgresContentsAPITest, self).setUp()
 
+        self.addCleanup(self.pg_manager.engine.dispose)
+        if hasattr(self.pg_manager.checkpoints, 'engine'):
+            self.addCleanup(self.pg_manager.checkpoints.engine.dispose)
+
     def tearDown(self):
         super(PostgresContentsAPITest, self).tearDown()
         clear_test_db()
@@ -448,6 +452,7 @@ class PostgresCheckpointsAPITest(_APITestBase):
     def setUp(self):
         super(PostgresCheckpointsAPITest, self).setUp()
         self.checkpoints.ensure_user()
+        self.addCleanup(self.checkpoints.engine.dispose)
 
     def tearDown(self):
         self.checkpoints.purge_db()

--- a/pgcontents/tests/test_synchronization.py
+++ b/pgcontents/tests/test_synchronization.py
@@ -201,6 +201,12 @@ class TestGenerateNotebooks(TestCase):
     def tearDown(self):
         clear_test_db()
 
+    @staticmethod
+    def cleanup_pgcontents_managers(managers):
+        for manager in managers:
+            manager.engine.dispose()
+            manager.checkpoints.engine.dispose()
+
     def populate_users(self, user_ids):
         """
         Create a `PostgresContentsManager` and notebooks for each user.
@@ -252,6 +258,10 @@ class TestGenerateNotebooks(TestCase):
                     'test_generate_files1',
                     'test_generate_files2']
         (managers, paths) = self.populate_users(user_ids)
+
+        # Dispose of all engines created during this test to prevent leaked
+        # database connections.
+        self.addCleanup(self.cleanup_pgcontents_managers, managers.values())
 
         # Since the bad notebook is saved last, it will be hit only when no
         # max_dt is specified.
@@ -339,6 +349,10 @@ class TestGenerateNotebooks(TestCase):
                     'test_generate_checkpoints1',
                     'test_generate_checkpoints2']
         (managers, paths) = self.populate_users(user_ids)
+
+        # Dispose of all engines created during this test to prevent leaked
+        # database connections.
+        self.addCleanup(self.cleanup_pgcontents_managers, managers.values())
 
         def update_content(user_id, path, text):
             """


### PR DESCRIPTION
When running the full test suite (`nosetests pgcontents/tests/`) it was possible to reach the maximum number of connections allowed to the [test database](https://github.com/quantopian/pgcontents/blob/cf7bc6db4d5de92dec14fd18d937938ef003af26/pgcontents/tests/utils.py#L29). This could been seen by tracking the connections via:

```
$ psql
# select count(*) from pg_stat_activity where datname = 'pgcontents_testing'; \watch 1
```

while running the tests. The [SQLAlchemy docs](https://docs.sqlalchemy.org/en/13/core/connections.html#engine-disposal) recommend disposing of engines if many are created during tests.