### PR TITLE
Updated to support Jupyter Notebook 7 and Jupyter Lab

### DIFF
--- a/pgcontents/pgmanager.py
+++ b/pgcontents/pgmanager.py
@@ -18,7 +18,12 @@ PostgreSQL implementation of IPython/Jupyter ContentsManager API.
 from __future__ import unicode_literals
 from itertools import chain
 from tornado import web
-from traitlets import default, Unicode
+from traitlets import (
+    Unicode, 
+    default, 
+)
+
+from jupyter_server.transutils import _i18n
 
 from .api_utils import (
     base_directory_model,
@@ -72,10 +77,15 @@ class PostgresContentsManager(PostgresManagerMixin, ContentsManager):
         help="Create a root directory automatically?",
     )
     
-    # Added to prevent jupyter lab failure
-    #root_dir = Unicode("/notebooks", config=True)
-    #preferred_dir = Unicode("/notebooks", config=True)
-    root_dir = None
+    root_dir = Unicode("/", config=True)
+
+    preferred_dir = Unicode(
+        "",
+        config=True,
+        help=_i18n(
+            "Preferred starting directory to use for notebooks. This is an API path (`/` separated, relative to root dir)"
+        ),
+    )
 
     @default('checkpoints_class')
     def _default_checkpoints_class(self):
@@ -109,7 +119,7 @@ class PostgresContentsManager(PostgresManagerMixin, ContentsManager):
 
     def ensure_root_directory(self):
         with self.engine.begin() as db:
-            ensure_directory(db, self.user_id, '')
+            ensure_directory(db, self.user_id, self.root_dir)
 
     def purge_db(self):
         """

--- a/pgcontents/pgmanager.py
+++ b/pgcontents/pgmanager.py
@@ -18,7 +18,7 @@ PostgreSQL implementation of IPython/Jupyter ContentsManager API.
 from __future__ import unicode_literals
 from itertools import chain
 from tornado import web
-from traitlets import default
+from traitlets import default, Unicode
 
 from .api_utils import (
     base_directory_model,
@@ -65,6 +65,12 @@ class PostgresContentsManager(PostgresManagerMixin, ContentsManager):
     ContentsManager that persists to a postgres database rather than to the
     local filesystem.
     """
+
+    # Added to prevent jupyter lab failure
+    root_dir = Unicode("/", config=True)
+
+    preferred_dir = Unicode("", config=True)
+
     create_directory_on_startup = Bool(
         config=True,
         help="Create a root directory automatically?",

--- a/pgcontents/pgmanager.py
+++ b/pgcontents/pgmanager.py
@@ -66,15 +66,16 @@ class PostgresContentsManager(PostgresManagerMixin, ContentsManager):
     local filesystem.
     """
 
-    # Added to prevent jupyter lab failure
-    root_dir = Unicode("/", config=True)
-
-    preferred_dir = Unicode("", config=True)
 
     create_directory_on_startup = Bool(
         config=True,
         help="Create a root directory automatically?",
     )
+    
+    # Added to prevent jupyter lab failure
+    #root_dir = Unicode("/notebooks", config=True)
+    #preferred_dir = Unicode("/notebooks", config=True)
+    root_dir = None
 
     @default('checkpoints_class')
     def _default_checkpoints_class(self):

--- a/pgcontents/utils/ipycompat.py
+++ b/pgcontents/utils/ipycompat.py
@@ -13,18 +13,6 @@ from jupyter_server.services.contents.filecheckpoints import (
 )
 from jupyter_server.services.contents.manager import ContentsManager
 from jupyter_server.utils import to_os_path
-"""
-from notebook.services.contents.checkpoints import (
-    Checkpoints,
-    GenericCheckpointsMixin,
-)
-from notebook.services.contents.filemanager import FileContentsManager
-from notebook.services.contents.filecheckpoints import (
-    GenericFileCheckpoints
-)
-from notebook.services.contents.manager import ContentsManager
-from notebook.utils import to_os_path
-"""
 from nbformat import from_dict, reads, writes
 from nbformat.v4.nbbase import (
     new_code_cell,

--- a/pgcontents/utils/ipycompat.py
+++ b/pgcontents/utils/ipycompat.py
@@ -2,6 +2,18 @@
 Utilities for managing compat between notebook versions.
 """
 from traitlets.config import Config
+
+from jupyter_server.services.contents.checkpoints import (
+    Checkpoints,
+    GenericCheckpointsMixin,
+)
+from jupyter_server.services.contents.filemanager import FileContentsManager
+from jupyter_server.services.contents.filecheckpoints import (
+    GenericFileCheckpoints
+)
+from jupyter_server.services.contents.manager import ContentsManager
+from jupyter_server.utils import to_os_path
+"""
 from notebook.services.contents.checkpoints import (
     Checkpoints,
     GenericCheckpointsMixin,
@@ -12,6 +24,7 @@ from notebook.services.contents.filecheckpoints import (
 )
 from notebook.services.contents.manager import ContentsManager
 from notebook.utils import to_os_path
+"""
 from nbformat import from_dict, reads, writes
 from nbformat.v4.nbbase import (
     new_code_cell,


### PR DESCRIPTION
I updated the repository to use jupyter_server instead of notebook packages since notebook is being phased out and replaced by jupyter server.

I also added root_dir and preferred_dir as attributes to the PostgresContentsManager class (without them the build was failing).